### PR TITLE
Network: couche réseau et outil de débogage

### DIFF
--- a/.github/docker/habanga-ci.dockerfile
+++ b/.github/docker/habanga-ci.dockerfile
@@ -1,0 +1,5 @@
+
+FROM ghcr.io/sim590/habanga-deps:latest
+LABEL maintainer="Simon Désaulniers <sim.desaulniers@gmail.com>"
+LABEL org.opencontainers.image.source="https://github.com/sim590/habanga"
+

--- a/.github/docker/habanga-ci.dockerfile
+++ b/.github/docker/habanga-ci.dockerfile
@@ -3,3 +3,6 @@ FROM ghcr.io/sim590/habanga-deps:latest
 LABEL maintainer="Simon Désaulniers <sim.desaulniers@gmail.com>"
 LABEL org.opencontainers.image.source="https://github.com/sim590/habanga"
 
+RUN apt update
+RUN apt install sudo curl
+

--- a/.github/docker/habanga-deps.dockerfile
+++ b/.github/docker/habanga-deps.dockerfile
@@ -1,0 +1,5 @@
+
+FROM ghcr.io/sim590/opendht-hs-deps:latest
+LABEL maintainer="Simon Désaulniers <sim.desaulniers@gmail.com>"
+LABEL org.opencontainers.image.source="https://github.com/sim590/habanga"
+

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: haskell-actions/setup@v2
       with:
         ghc-version: '9.4.8'
-        cabal-version: '3.12.1.0'
+        cabal-version: '3.10.3.0'
 
     - name: Cache
       uses: actions/cache@v3
@@ -34,8 +34,9 @@ jobs:
           ${{ runner.os }}-build-${{ env.cache-name }}-
           ${{ runner.os }}-build-
           ${{ runner.os }}-
-    - name: Installation des dépendance système
-      run: sudo apt install libopendht-c-dev gcc
+
+    - name: Install opendht-c
+      run: sudo apt install libopendht-c-dev
     - name: Build
       run: cabal v2-build --enable-tests --enable-benchmarks all
     - name: Run tests

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        submodules: recursive
     - uses: haskell-actions/setup@v2
       with:
         ghc-version: '9.4.8'

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -37,10 +37,6 @@ jobs:
 
     - name: Install opendht-c
       run: sudo apt install libopendht-c-dev
-    - name: Install dependencies
-      run: |
-        cabal update
-        cabal v2-build --only-dependencies --enable-tests --enable-benchmarks
     - name: Build
       run: cabal v2-build --enable-tests --enable-benchmarks all
     - name: Run tests

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         cabal update
-        cabal build --only-dependencies --enable-tests --enable-benchmarks
+        cabal v2-build --only-dependencies --enable-tests --enable-benchmarks
     - name: Build
       run: cabal v2-build --enable-tests --enable-benchmarks all
     - name: Run tests

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -21,7 +21,7 @@ jobs:
     - uses: haskell-actions/setup@v2
       with:
         ghc-version: '9.4.8'
-        cabal-version: '3.10.3.0'
+        cabal-version: '3.12.1.0'
 
     - name: Cache
       uses: actions/cache@v3
@@ -34,9 +34,8 @@ jobs:
           ${{ runner.os }}-build-${{ env.cache-name }}-
           ${{ runner.os }}-build-
           ${{ runner.os }}-
-
-    - name: Install opendht-c
-      run: sudo apt install libopendht-c-dev
+    - name: Installation des dépendance système
+      run: sudo apt install libopendht-c-dev gcc
     - name: Build
       run: cabal v2-build --enable-tests --enable-benchmarks all
     - name: Run tests

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -35,6 +35,8 @@ jobs:
           ${{ runner.os }}-build-
           ${{ runner.os }}-
 
+    - name: Install opendht-c
+      run: sudo apt install libopendht-c-dev
     - name: Install dependencies
       run: |
         cabal update

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -13,7 +13,11 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    container:
+      image: ghcr.io/sim590/opendht-hs-ci
+      credentials:
+        username: sim590
+        password: ${{ secrets.DOCKER_CONTAINER_REGISTRY_TOKEN }}
     steps:
     - uses: actions/checkout@v4
       with:
@@ -34,9 +38,6 @@ jobs:
           ${{ runner.os }}-build-${{ env.cache-name }}-
           ${{ runner.os }}-build-
           ${{ runner.os }}-
-
-    - name: Install opendht-c
-      run: sudo apt install libopendht-c-dev
     - name: Build
       run: cabal v2-build --enable-tests --enable-benchmarks all
     - name: Run tests

--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -14,7 +14,7 @@ jobs:
 
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/sim590/opendht-hs-ci
+      image: ghcr.io/sim590/habanga-ci
       credentials:
         username: sim590
         password: ${{ secrets.DOCKER_CONTAINER_REGISTRY_TOKEN }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "deps/opendht-hs"]
+	path = deps/opendht-hs
+	url = https://github.com/sim590/opendht-hs/

--- a/cabal.project.local
+++ b/cabal.project.local
@@ -1,0 +1,1 @@
+packages: ., deps/opendht-hs/

--- a/habanga.cabal
+++ b/habanga.cabal
@@ -55,6 +55,7 @@ library habanga-core
     exposed-modules:    Game
                         Cards
                         GameState
+                        Random
     build-depends:      random >= 1.2.1 && < 1.3
     hs-source-dirs:     src/core
 

--- a/habanga.cabal
+++ b/habanga.cabal
@@ -47,6 +47,7 @@ common common-base
                         transformers ^>= 0.5.6,
                         lens         ^>= 5.3.3,
                         mtl          ^>= 2.2.2,
+                        containers   ^>= 0.6.7,
                         data-default ^>= 0.8.0
 
 library habanga-core
@@ -72,7 +73,6 @@ executable habanga-tui
                         GameView,
                         Widgets
     build-depends:      habanga-core,
-                        containers        ^>= 0.6.7,
                         text              ^>= 2.0.2,
                         brick             ^>= 2.6,
                         vty               ^>= 6.2,

--- a/habanga.cabal
+++ b/habanga.cabal
@@ -55,8 +55,12 @@ library habanga-core
     exposed-modules:    Game
                         Cards
                         GameState
+                        Network
     build-depends:      random >= 1.2.1 && < 1.3,
-                        opendht-hs
+                        opendht-hs,
+                        serialise,
+                        bytestring,
+                        stm
     hs-source-dirs:     src/core
 
 executable habanga-tui

--- a/habanga.cabal
+++ b/habanga.cabal
@@ -49,7 +49,8 @@ common common-base
                         mtl          ^>= 2.2.2,
                         containers   ^>= 0.6.7,
                         data-default ^>= 0.8.0,
-                        stm
+                        stm,
+                        extra
 common common-exe
     ghc-options:        -threaded
 

--- a/habanga.cabal
+++ b/habanga.cabal
@@ -65,6 +65,7 @@ library habanga-core
     exposed-modules:    Game
                         Cards
                         GameState
+                        NetworkState
                         Network
                         Random
     build-depends:      random >= 1.2.1 && < 1.3,

--- a/habanga.cabal
+++ b/habanga.cabal
@@ -81,6 +81,7 @@ executable habanga-node
     main-is:            Main.hs
     other-modules:      Node
     build-depends:      habanga-core,
+                        random
     hs-source-dirs:     src/tools/node
 
 executable habanga-tui

--- a/habanga.cabal
+++ b/habanga.cabal
@@ -55,7 +55,8 @@ library habanga-core
     exposed-modules:    Game
                         Cards
                         GameState
-    build-depends:      random >= 1.2.1 && < 1.3
+    build-depends:      random >= 1.2.1 && < 1.3,
+                        opendht-hs
     hs-source-dirs:     src/core
 
 executable habanga-tui

--- a/habanga.cabal
+++ b/habanga.cabal
@@ -48,7 +48,16 @@ common common-base
                         lens         ^>= 5.3.3,
                         mtl          ^>= 2.2.2,
                         containers   ^>= 0.6.7,
-                        data-default ^>= 0.8.0
+                        data-default ^>= 0.8.0,
+                        stm
+common common-exe
+    ghc-options:        -threaded
+
+common brick
+    build-depends:
+                        brick             ^>= 2.6,
+                        vty               ^>= 6.2,
+                        vty-crossplatform ^>= 0.4.0,
 
 library habanga-core
     import:             common-base,
@@ -60,24 +69,31 @@ library habanga-core
     build-depends:      random >= 1.2.1 && < 1.3,
                         opendht-hs,
                         serialise,
-                        bytestring,
-                        stm
+                        bytestring
     hs-source-dirs:     src/core
+
+executable habanga-node
+    import:             common-base,
+                        common-lang,
+                        common-exe,
+                        brick
+    main-is:            Main.hs
+    other-modules:      Node
+    build-depends:      habanga-core,
+    hs-source-dirs:     src/tools/node
 
 executable habanga-tui
     import:             common-base,
-                        common-lang
+                        common-lang,
+                        common-exe,
+                        brick
     main-is:            Main.hs
     other-modules:      ProgramState,
                         MainMenu,
                         GameView,
                         Widgets
     build-depends:      habanga-core,
-                        text              ^>= 2.0.2,
-                        brick             ^>= 2.6,
-                        vty               ^>= 6.2,
-                        vty-crossplatform ^>= 0.4.0,
-                        file-embed        ^>= 0.0.16
+                        text       ^>= 2.0.2,
+                        file-embed ^>= 0.0.16
     hs-source-dirs:     src/tui
-    ghc-options:        -threaded
 

--- a/habanga.cabal
+++ b/habanga.cabal
@@ -43,11 +43,11 @@ common common-lang
                         -Wincomplete-uni-patterns -Wredundant-constraints
 
 common common-base
-    build-depends:      base ^>=4.17.2.1,
-                        transformers >= 0.5.6 && < 0.6,
-                        lens >= 5.3.3 && < 5.4,
-                        mtl >= 2.2.2 && < 2.3,
-                        data-default >= 0.8.0 && < 0.9
+    build-depends:      base         ^>= 4.17.2.1,
+                        transformers ^>= 0.5.6,
+                        lens         ^>= 5.3.3,
+                        mtl          ^>= 2.2.2,
+                        data-default ^>= 0.8.0
 
 library habanga-core
     import:             common-base,
@@ -67,12 +67,12 @@ executable habanga-tui
                         GameView,
                         Widgets
     build-depends:      habanga-core,
-                        containers >= 0.6.7 && < 0.7,
-                        text >= 2.0.2 && < 2.1,
-                        brick >= 2.6 && < 2.7,
-                        vty >= 6.2 && < 6.3,
-                        vty-crossplatform >= 0.4.0 && < 0.5,
-                        file-embed >= 0.0.16 && < 0.1
+                        containers        ^>= 0.6.7,
+                        text              ^>= 2.0.2,
+                        brick             ^>= 2.6,
+                        vty               ^>= 6.2,
+                        vty-crossplatform ^>= 0.4.0,
+                        file-embed        ^>= 0.0.16
     hs-source-dirs:     src/tui
     ghc-options:        -threaded
 

--- a/hie.yaml
+++ b/hie.yaml
@@ -5,6 +5,8 @@ cradle:
       component: "habanga-core"
     - path: "src/tui"
       component: "habanga-tui"
+    - path: "src/tools/node"
+      component: "habanga-node"
 
 #  vim: set sts=2 ts=4 sw=2 tw=80 et :
 

--- a/src/core/Cards.hs
+++ b/src/core/Cards.hs
@@ -29,7 +29,7 @@ import Codec.Serialise
 import GHC.Generics
 
 data Color = Red | Yellow | Blue | Purple
-  deriving (Eq, Ord, Generic, Data)
+  deriving (Eq, Ord, Generic, Data, Read)
 
 data Card  = Card { _value :: Int
                   , _color :: Maybe Color

--- a/src/core/Cards.hs
+++ b/src/core/Cards.hs
@@ -14,21 +14,31 @@
 -}
 
 {-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveDataTypeable #-}
 
 module Cards where
 
+import Data.Data
 import Data.Default
 
 import Control.Lens
 
+import Codec.Serialise
+
+import GHC.Generics
+
 data Color = Red | Yellow | Blue | Purple
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Generic, Data)
 
 data Card  = Card { _value :: Int
                   , _color :: Maybe Color
                   }
-                  deriving (Eq, Ord)
+                  deriving (Eq, Ord, Generic, Data)
 makeLenses ''Card
+
+instance Serialise Color
+instance Serialise Card
 
 instance Show Color where
   show Red    = "Rouge"

--- a/src/core/Cards.hs
+++ b/src/core/Cards.hs
@@ -17,11 +17,8 @@
 
 module Cards where
 
-import System.Random
-
 import Data.Default
 
-import Control.Monad.State
 import Control.Lens
 
 data Color = Red | Yellow | Blue | Purple
@@ -66,17 +63,6 @@ fits :: Card -> Maybe Color -> (Int, Int) -> Bool
 fits (Card v0 col0) col1 (v1, v2)
   | col0 /= col1 = False
   | otherwise    = min v1 v2 < v0 && v0 < max v1 v2
-
-shuffleCards :: [Card] -> IO [Card]
-shuffleCards cards = flip evalStateT cards $ replicateM (length cards) $ do
-  l <- get
-  s <- randomIO
-  let r = s `mod` length l
-  case splitAt r l of
-    (beg, c:end) -> do
-      put (beg ++ end)
-      return c
-    (_, []) -> error "shuffleCards: la liste était vide. Ceci n'aurait pas dû se produire..."
 
 --  vim: set sts=2 ts=2 sw=2 tw=120 et :
 

--- a/src/core/Game.hs
+++ b/src/core/Game.hs
@@ -13,6 +13,7 @@
 
 module Game ( initializeIO
             , initialize
+            , reInitialize
             , winner
             , processPlayerTurnAction
             , RangeBoundary (..)
@@ -64,6 +65,12 @@ initialize playerNames gen = do
   flip execStateT initialGameState $ replicateM_ (length playerNames) $ do
     drawCards 8
     endPlayerTurn
+
+reInitialize :: RandomGen gen => [String] -> GameState -> gen -> IO GameState
+reInitialize playerNames gs gen = initialize playerNames gen >>= \ gs' -> return $ gs
+  & cardsOnTable .~ gs' ^. cardsOnTable
+  & deck         .~ gs' ^. deck
+  & players      .~ gs' ^. players
 
 {-| Exécute toute les actions nécessaires lors de la terminaison du tour
    du joueur.

--- a/src/core/Game.hs
+++ b/src/core/Game.hs
@@ -94,6 +94,9 @@ winner = do
 
    La fonction retourne le nombre de cartes pigées par le joueur à la fin de son tour.
 -}
+-- TODO: de façon à utiliser TVar
+-- processPlayerTurnAction
+--   :: (MonadIO m, MonadState s m, GameStated s)
 processPlayerTurnAction
   :: (MonadState s m, GameStated s)
   => Card          -- ^ La carte jouée par le joueur.

--- a/src/core/Game.hs
+++ b/src/core/Game.hs
@@ -24,6 +24,7 @@ import Control.Monad.Trans.Maybe
 import Control.Monad.State
 import Control.Lens
 
+import Random
 import Cards
 import GameState
 
@@ -40,13 +41,13 @@ initialize
   :: [String] -- ^ Les noms des différents joueurs.
   -> IO GameState
 initialize playerNames = do
-  startingRangesCardsShuffled <- shuffleCards startingRangesCardList
+  startingRangesCardsShuffled <- shuffle startingRangesCardList
   let theCardsOnTable     = CardsOnTable (startingRangesCardsShuffled !! 0, startingRangesCardsShuffled !! 1)
                                          (startingRangesCardsShuffled !! 2, startingRangesCardsShuffled !! 3)
                                          (startingRangesCardsShuffled !! 4, startingRangesCardsShuffled !! 5)
                                          (startingRangesCardsShuffled !! 6, startingRangesCardsShuffled !! 7)
       initialPlayerStates = map (\ n -> PlayerState n [] Nothing) playerNames
-  shuffledDeck <- shuffleCards unshuffledDeck
+  shuffledDeck <- shuffle unshuffledDeck
 
   let initialGameState = GameState theCardsOnTable shuffledDeck initialPlayerStates
   flip execStateT initialGameState $ replicateM_ (length playerNames) $ do

--- a/src/core/Game.hs
+++ b/src/core/Game.hs
@@ -58,11 +58,12 @@ initialize playerNames = do
 -}
 endPlayerTurn :: (MonadState s m, GameStated s) => m ()
 endPlayerTurn = do
-  let cycleAround (p:others) = others ++ [p]
-      cycleAround [] = error "endPlayerTurn: aucun joueur!"
-      sortByColor  = List.sortBy (\ c0 c1 -> compare (c0^.color) (c1^.color))
-      groupByColor = List.groupBy (\ c0 c1 -> c0^.color == c1^.color)
-      sortByColorThenValues = concat . over traverse List.sort . groupByColor . sortByColor
+  let
+    cycleAround (p:others) = others ++ [p]
+    cycleAround []         = error "endPlayerTurn: aucun joueur!"
+    sortByColor            = List.sortBy (\ c0 c1 -> compare (c0^.color) (c1^.color))
+    groupByColor           = List.groupBy (\ c0 c1 -> c0^.color == c1^.color)
+    sortByColorThenValues  = concat . over traverse List.sort . groupByColor . sortByColor
   gameStateLens . players . _head . cardsInHand %= sortByColorThenValues
   gameStateLens . players %= cycleAround
 
@@ -94,9 +95,7 @@ winner = do
 
    La fonction retourne le nombre de cartes pigées par le joueur à la fin de son tour.
 -}
--- TODO: de façon à utiliser TVar
--- processPlayerTurnAction
---   :: (MonadIO m, MonadState s m, GameStated s)
+
 processPlayerTurnAction
   :: (MonadState s m, GameStated s)
   => Card          -- ^ La carte jouée par le joueur.
@@ -115,15 +114,15 @@ processPlayerTurnAction card side = do
   (gameStateLens . players . _head . cardsInHand) %= List.delete card
 
   let boundaryLens = case side of
-                       LeftBoundary  -> _1
-                       RightBoundary -> _2
+       LeftBoundary  -> _1
+       RightBoundary -> _2
 
   let colorLens c = case c^.color of
-                      Just Red    -> red
-                      Just Yellow -> yellow
-                      Just Blue   -> blue
-                      Just Purple -> purple
-                      Nothing     -> error "processPlayerTurnAction: la carte d'un des joueurs n'avait pas de couleur."
+        Just Red    -> red
+        Just Yellow -> yellow
+        Just Blue   -> blue
+        Just Purple -> purple
+        Nothing     -> error "processPlayerTurnAction: la carte d'un des joueurs n'avait pas de couleur."
 
 
   gameStateLens . cardsOnTable . colorLens card . boundaryLens .= card

--- a/src/core/Game.hs
+++ b/src/core/Game.hs
@@ -14,6 +14,7 @@
 module Game ( initializeIO
             , initialize
             , reInitialize
+            , fromEitherCard
             , winner
             , processPlayerTurnAction
             , RangeBoundary (..)
@@ -33,6 +34,10 @@ import Cards
 import GameState
 
 data RangeBoundary = LeftBoundary | RightBoundary
+
+fromEitherCard :: Either Card Card -> (Card, RangeBoundary)
+fromEitherCard (Left c)  = (c, LeftBoundary)
+fromEitherCard (Right c) = (c, RightBoundary)
 
 initializeIO
   :: [String]     -- ^ Les noms des différents joueurs.

--- a/src/core/GameState.hs
+++ b/src/core/GameState.hs
@@ -20,7 +20,6 @@ import Control.Lens
 
 import Cards
 
-
 data CardsOnTable = CardsOnTable { _red    :: (Card, Card)
                                  , _yellow :: (Card, Card)
                                  , _blue   :: (Card, Card)
@@ -40,13 +39,32 @@ makeLenses ''PlayerState
 instance Show PlayerState where
   show p = (p^.name) ++ ": " ++ show (p^.cardsInHand)
 
+type GameCode = String
+
+data NetworkStatus = Awaiting
+                   | AwaitingConnection
+                   | AwaitingPlayerAction
+                   | AwaitingOtherPlayerAction
+                   | GameConnectionFail
+                   | EndingGame
+                   | ShuttingDown
+
 data GameState = GameState { _cardsOnTable :: CardsOnTable
                            , _deck         :: [Card]
                            , _players      :: [PlayerState]
                            }
+               | OnlineGameState { _cardsOnTable  :: CardsOnTable
+                                 , _deck          :: [Card]
+                                 , _players       :: [PlayerState]
+                                 , _networkStatus :: NetworkStatus
+                                 , _gameCode      :: GameCode
+                                 }
 makeLenses ''GameState
 
 class GameStated a where
+  -- TODO: de façon à utiliser TVar
+  -- getGameState :: a -> IO GameState
+  -- setGameState :: a -> GameState -> IO a
   getGameState :: a -> GameState
   setGameState :: a -> GameState -> a
 

--- a/src/core/GameState.hs
+++ b/src/core/GameState.hs
@@ -55,6 +55,7 @@ data OnlineGameStatus = AwaitingPlayerTurn
 data NetworkRequest = GameAnnounce
                     | JoinGame
                     | GameStart
+                    | ResetNetwork
                     deriving Show
 data NetworkEvent = Connection
                   | GameStarted

--- a/src/core/GameState.hs
+++ b/src/core/GameState.hs
@@ -69,6 +69,7 @@ data GameState = GameState { _cardsOnTable :: CardsOnTable
                                  , _playersIdentities     :: Map OnlinePlayerID OnlinePlayerName
                                  , _networkStatus         :: NetworkStatus
                                  , _gameSettings          :: OnlineGameSettings
+                                 , _myID                  :: String
                                  }
 makeLenses ''GameState
 

--- a/src/core/GameState.hs
+++ b/src/core/GameState.hs
@@ -54,10 +54,10 @@ data NetworkStatus = Awaiting
                    | EndingGame
                    | ShuttingDown
 
-data GameSettings = GameSettings { _gameCode        :: GameCode
-                                 , _numberOfPlayers :: Int
-                                 }
-makeLenses ''GameSettings
+data OnlineGameSettings = OnlineGameSettings { _gameCode        :: GameCode
+                                             , _numberOfPlayers :: Int
+                                             }
+makeLenses ''OnlineGameSettings
 
 data GameState = GameState { _cardsOnTable :: CardsOnTable
                            , _deck         :: [Card]
@@ -68,7 +68,7 @@ data GameState = GameState { _cardsOnTable :: CardsOnTable
                                  , _players               :: [PlayerState]
                                  , _playersIdentities     :: Map OnlinePlayerID OnlinePlayerName
                                  , _networkStatus         :: NetworkStatus
-                                 , _gameSettings          :: GameSettings
+                                 , _gameSettings          :: OnlineGameSettings
                                  }
 makeLenses ''GameState
 

--- a/src/core/GameState.hs
+++ b/src/core/GameState.hs
@@ -50,7 +50,7 @@ data NetworkStatus = Awaiting
                    | AwaitingPlayerTurn
                    | AwaitingOtherPlayerTurn
                    | RequestGameAnnounce
-                   | GameAnnouncementFailure
+                   | GameAnnouncementFailure String
                    | EndingGame
                    | ShuttingDown
 

--- a/src/core/GameState.hs
+++ b/src/core/GameState.hs
@@ -63,6 +63,7 @@ data NetworkStatus = AwaitingRequest
                    | AwaitingEvent NetworkEvent
                    | Request NetworkRequest
                    | SharingGameSetup
+                   | SetupPhaseDone
                    | GameInitialization
                    | GameOnGoing OnlineGameStatus
                    | EndingGame

--- a/src/core/GameState.hs
+++ b/src/core/GameState.hs
@@ -13,6 +13,7 @@
 
 module GameState where
 
+import Data.Map (Map)
 import Data.Default
 import qualified Data.List as List
 
@@ -41,23 +42,33 @@ instance Show PlayerState where
 
 type GameCode = String
 
+type OnlinePlayerID = String
+type OnlinePlayerName = String
+
 data NetworkStatus = Awaiting
                    | AwaitingConnection
-                   | AwaitingPlayerAction
-                   | AwaitingOtherPlayerAction
-                   | GameConnectionFail
+                   | AwaitingPlayerTurn
+                   | AwaitingOtherPlayerTurn
+                   | RequestGameAnnounce
+                   | GameAnnouncementFailure
                    | EndingGame
                    | ShuttingDown
+
+data GameSettings = GameSettings { _gameCode        :: GameCode
+                                 , _numberOfPlayers :: Int
+                                 }
+makeLenses ''GameSettings
 
 data GameState = GameState { _cardsOnTable :: CardsOnTable
                            , _deck         :: [Card]
                            , _players      :: [PlayerState]
                            }
-               | OnlineGameState { _cardsOnTable  :: CardsOnTable
-                                 , _deck          :: [Card]
-                                 , _players       :: [PlayerState]
-                                 , _networkStatus :: NetworkStatus
-                                 , _gameCode      :: GameCode
+               | OnlineGameState { _cardsOnTable          :: CardsOnTable
+                                 , _deck                  :: [Card]
+                                 , _players               :: [PlayerState]
+                                 , _playersIdentities     :: Map OnlinePlayerID OnlinePlayerName
+                                 , _networkStatus         :: NetworkStatus
+                                 , _gameSettings          :: GameSettings
                                  }
 makeLenses ''GameState
 
@@ -92,6 +103,9 @@ instance Show GameState where
          ++ List.intercalate "\n" [ "Cards on table:"
                                   , List.intercalate "\n" $ map ("\t"++) (lines (show $ gs^.cardsOnTable))
                                   ]
+
+_MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ :: Int
+_MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ = 6
 
 {-| Lentille (Lens' s GameState)
 

--- a/src/core/GameState.hs
+++ b/src/core/GameState.hs
@@ -13,14 +13,14 @@
 
 module GameState where
 
-import Data.Word
-import Data.Map (Map)
-import qualified Data.Map as Map
 import Data.Default
 
 import Control.Lens
+import Control.Monad.IO.Class
+import Control.Concurrent.STM
 
 import Cards
+import NetworkState
 
 data CardsOnTable = CardsOnTable { _red    :: (Card, Card)
                                  , _yellow :: (Card, Card)
@@ -41,61 +41,14 @@ makeLenses ''PlayerState
 instance Show PlayerState where
   show p = (p^.name) ++ ": " ++ show (p^.cardsInHand)
 
-type GameCode = String
-
-type OnlinePlayerID = String
-type OnlinePlayerName = String
-
-data NetworkFailureType = GameAnnouncementFailure String
-                        | GameJoinRequestFailure String
-                        | ShareGameSetupFailure String
-                        deriving Show
-data OnlineGameStatus = AwaitingPlayerTurn
-                      | AwaitingOtherPlayerTurn
-                      deriving Show
-data NetworkRequest = GameAnnounce OnlineGameSettings String
-                    | JoinGame GameCode String
-                    | GameStart
-                    | PlayTurn (Either Card Card)
-                    | ResetNetwork
-                    deriving Show
-data NetworkEvent = Connection
-                  | GameStarted
-                  deriving Show
-data NetworkStatus = AwaitingRequest
-                   | AwaitingEvent NetworkEvent
-                   | Request NetworkRequest
-                   | SharingGameSetup
-                   | SetupPhaseDone
-                   | GameReadyForInitialization
-                   | GameOnGoing OnlineGameStatus
-                   | GameEnded
-                   | ShuttingDown
-                   | NetworkFailure NetworkFailureType
-                   deriving Show
-
-data OnlineGameSettings = OnlineGameSettings { _gameCode        :: GameCode
-                                             , _numberOfPlayers :: Int
-                                             }
-                                             deriving Show
-makeLenses ''OnlineGameSettings
-
 data GameState = GameState { _cardsOnTable :: CardsOnTable
                            , _deck         :: [Card]
                            , _players      :: [PlayerState]
                            }
-               | OnlineGameState { _cardsOnTable          :: CardsOnTable
-                                 , _deck                  :: [Card]
-                                 , _players               :: [PlayerState]
-                                 , _gameTurns             :: Map Word16 (Either Card Card)
-                                 , _playersIdentities     :: Map OnlinePlayerID OnlinePlayerName
-                                 , _networkStatus         :: NetworkStatus
-                                 , _gameSettings          :: OnlineGameSettings
-                                 , _gameHostID            :: String
-                                 , _turnNumber            :: Word16
-                                 , _myID                  :: String
-                                 , _myName                :: String
-                                 , _myPlayerRank          :: Int
+               | OnlineGameState { _cardsOnTable :: CardsOnTable
+                                 , _deck         :: [Card]
+                                 , _players      :: [PlayerState]
+                                 , _networkState :: TVar NetworkState
                                  }
 makeLenses ''GameState
 
@@ -125,59 +78,24 @@ instance Show CardsOnTable where
                     ]
 
 instance Show GameState where
-  show gs@(GameState {}) = unlines [ "Deck:"
-                                   , "    " ++ show (gs^.deck)
-                                   , "Players: "
-                                   ]
-                           ++ "\n"
-                           ++ unlines (map (("    "++) . show) (gs^.players))
-                           ++ "\n"
-                           ++ unlines [ "Cards on table:"
-                                      , unlines $ map ("    "++) (lines (show $ gs^.cardsOnTable))
-                                      ]
-  show gs@(OnlineGameState {}) = show (GameState (gs^.cardsOnTable) (gs^.deck) (gs^.players))
-                                 ++ unlines [ "GameTurns:"
-                                            , "    " <> show (Map.toList $ gs ^. gameTurns)
-                                            , "Player IDs:"
-                                            , "    " <> show (Map.toList (gs^.playersIdentities))
-                                            , "NetworkStatus: "  <> show (gs^?!networkStatus)
-                                            , "GameSettings:"
-                                            , "    " <> " GameCode:        " <> gs^.gameSettings.gameCode
-                                            , "    " <> " NumberOfPlayers: " <> show (gs^?!gameSettings.numberOfPlayers)
-                                            , "GameHostID:   " <> gs ^. gameHostID
-                                            , "MyID:         " <> gs ^. myID
-                                            , "MyName:       " <> gs ^. myName
-                                            , "MyPlayerRank: " <> show (gs ^?! myPlayerRank)
-                                            ]
+  show gs = unlines [ "Deck:"
+                    , "    " ++ show (gs^.deck)
+                    , "Players: "
+                    ]
+            ++ "\n"
+            ++ unlines (map (("    "++) . show) (gs^.players))
+            ++ "\n"
+            ++ unlines [ "Cards on table:"
+                      , unlines $ map ("    "++) (lines (show $ gs^.cardsOnTable))
+                      ]
 
-_MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ :: Int
-_MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ = 6
-
-defaultOnlineGameState :: GameState
-defaultOnlineGameState = OnlineGameState { _cardsOnTable      = def
-                                         , _deck              = []
-                                         , _players           = []
-                                         , _gameTurns         = Map.empty
-                                         , _playersIdentities = mempty
-                                         , _networkStatus     = AwaitingRequest
-                                         , _gameSettings      = OnlineGameSettings [] 0
-                                         , _gameHostID        = ""
-                                         , _turnNumber        = 0
-                                         , _myID              = ""
-                                         , _myName            = ""
-                                         , _myPlayerRank      = 0
-                                         }
-
-splitAtMissingTurn :: GameState -> Map Word16 (Either Card Card) -> ([(Word16, Either Card Card)], [(Word16, Either Card Card)])
-splitAtMissingTurn gs gameTurns' = (consecutivePlayerTurns', rest)
-  where
-    rest = map snd $ dropWhile (uncurry (==)) $ zip (Map.toList gameTurns') consecutivePlayerTurns'
-    consecutivePlayerTurns' = consecutivePlayerTurns gs gameTurns'
-
-consecutivePlayerTurns :: GameState -> Map Word16 (Either Card Card) -> [(Word16, Either Card Card)]
-consecutivePlayerTurns gs gameTurns' = map fst $ takeWhile turnIsSubsequent $ zip (Map.toList gameTurns') [gs^?!turnNumber..]
-  where
-    turnIsSubsequent ((t',_), t) = t' == t + 1
+defaultOnlineGameState :: MonadIO m => m GameState
+defaultOnlineGameState = liftIO (newTVarIO def) >>= \ nsTV ->
+  return OnlineGameState { _cardsOnTable = def ^. cardsOnTable
+                         , _deck         = def ^. deck
+                         , _players      = def ^. players
+                         , _networkState = nsTV
+                         }
 
 {-| Lentille (Lens' s GameState)
 

--- a/src/core/GameState.hs
+++ b/src/core/GameState.hs
@@ -64,6 +64,7 @@ data NetworkStatus = AwaitingRequest
                    | Request NetworkRequest
                    | SharingGameSetup
                    | GameInitialization
+                   | GameOnGoing OnlineGameStatus
                    | EndingGame
                    | ShuttingDown
                    | NetworkFailure NetworkFailureType

--- a/src/core/GameState.hs
+++ b/src/core/GameState.hs
@@ -52,8 +52,8 @@ data NetworkFailureType = GameAnnouncementFailure String
 data OnlineGameStatus = AwaitingPlayerTurn
                       | AwaitingOtherPlayerTurn
                       deriving Show
-data NetworkRequest = GameAnnounce
-                    | JoinGame
+data NetworkRequest = GameAnnounce OnlineGameSettings String
+                    | JoinGame GameCode String
                     | GameStart
                     | ResetNetwork
                     deriving Show
@@ -75,6 +75,7 @@ data NetworkStatus = AwaitingRequest
 data OnlineGameSettings = OnlineGameSettings { _gameCode        :: GameCode
                                              , _numberOfPlayers :: Int
                                              }
+                                             deriving Show
 makeLenses ''OnlineGameSettings
 
 data GameState = GameState { _cardsOnTable :: CardsOnTable

--- a/src/core/GameState.hs
+++ b/src/core/GameState.hs
@@ -47,7 +47,7 @@ type OnlinePlayerName = String
 
 data NetworkFailureType = GameAnnouncementFailure String
                         | GameJoinRequestFailure String
-                        | GameInitialSetupFailure String
+                        | ShareGameSetupFailure String
                         deriving Show
 data OnlineGameStatus = AwaitingPlayerTurn
                       | AwaitingOtherPlayerTurn

--- a/src/core/GameState.hs
+++ b/src/core/GameState.hs
@@ -48,11 +48,17 @@ type OnlinePlayerName = String
 data NetworkFailureType = GameAnnouncementFailure String
                         | GameJoinRequestFailure String
                         | GameInitialSetupFailure String
-data NetworkStatus = Awaiting
-                   | AwaitingConnection
-                   | AwaitingPlayerTurn
-                   | AwaitingOtherPlayerTurn
-                   | RequestGameAnnounce
+data OnlineGameStatus = AwaitingPlayerTurn
+                      | AwaitingOtherPlayerTurn
+data NetworkRequest = GameAnnounce
+                    | JoinGame
+                    | GameStart
+data NetworkEvent = Connection
+                  | GameStarted
+data NetworkStatus = AwaitingEvent NetworkEvent
+                   | Request NetworkRequest
+                   | GameOnGoing OnlineGameStatus
+                   | GameInitialization
                    | EndingGame
                    | ShuttingDown
                    | NetworkFailure NetworkFailureType

--- a/src/core/GameState.hs
+++ b/src/core/GameState.hs
@@ -45,14 +45,17 @@ type GameCode = String
 type OnlinePlayerID = String
 type OnlinePlayerName = String
 
+data NetworkFailureType = GameAnnouncementFailure String
+                        | GameJoinRequestFailure String
+                        | GameInitialSetupFailure String
 data NetworkStatus = Awaiting
                    | AwaitingConnection
                    | AwaitingPlayerTurn
                    | AwaitingOtherPlayerTurn
                    | RequestGameAnnounce
-                   | GameAnnouncementFailure String
                    | EndingGame
                    | ShuttingDown
+                   | NetworkFailure NetworkFailureType
 
 data OnlineGameSettings = OnlineGameSettings { _gameCode        :: GameCode
                                              , _numberOfPlayers :: Int

--- a/src/core/GameState.hs
+++ b/src/core/GameState.hs
@@ -65,7 +65,7 @@ data NetworkStatus = AwaitingRequest
                    | Request NetworkRequest
                    | SharingGameSetup
                    | SetupPhaseDone
-                   | GameInitialization
+                   | GameReadyForInitialization
                    | GameOnGoing OnlineGameStatus
                    | EndingGame
                    | ShuttingDown

--- a/src/core/GameState.hs
+++ b/src/core/GameState.hs
@@ -78,7 +78,9 @@ data GameState = GameState { _cardsOnTable :: CardsOnTable
                                  , _playersIdentities     :: Map OnlinePlayerID OnlinePlayerName
                                  , _networkStatus         :: NetworkStatus
                                  , _gameSettings          :: OnlineGameSettings
+                                 , _gameHostID            :: String
                                  , _myID                  :: String
+                                 , _myName                :: String
                                  }
 makeLenses ''GameState
 

--- a/src/core/GameState.hs
+++ b/src/core/GameState.hs
@@ -56,6 +56,8 @@ data NetworkRequest = GameAnnounce
 data NetworkEvent = Connection
                   | GameStarted
 data NetworkStatus = AwaitingEvent NetworkEvent
+data NetworkStatus = AwaitingRequest
+                   | AwaitingEvent NetworkEvent
                    | Request NetworkRequest
                    | GameOnGoing OnlineGameStatus
                    | GameInitialization

--- a/src/core/GameState.hs
+++ b/src/core/GameState.hs
@@ -141,6 +141,18 @@ instance Show GameState where
 _MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ :: Int
 _MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ = 6
 
+defaultOnlineGameState :: GameState
+defaultOnlineGameState = OnlineGameState { _cardsOnTable      = def
+                                         , _deck              = []
+                                         , _players           = []
+                                         , _playersIdentities = mempty
+                                         , _networkStatus     = AwaitingRequest
+                                         , _gameSettings      = OnlineGameSettings [] 0
+                                         , _gameHostID        = ""
+                                         , _myID              = ""
+                                         , _myName            = ""
+                                         }
+
 {-| Lentille (Lens' s GameState)
 
    Ceci permet d'interagir avec GameState dans (MonadState s).

--- a/src/core/GameState.hs
+++ b/src/core/GameState.hs
@@ -62,7 +62,7 @@ data NetworkEvent = Connection
 data NetworkStatus = AwaitingRequest
                    | AwaitingEvent NetworkEvent
                    | Request NetworkRequest
-                   | GameOnGoing OnlineGameStatus
+                   | SharingGameSetup
                    | GameInitialization
                    | EndingGame
                    | ShuttingDown

--- a/src/core/GameState.hs
+++ b/src/core/GameState.hs
@@ -69,7 +69,7 @@ data NetworkStatus = AwaitingRequest
                    | SetupPhaseDone
                    | GameReadyForInitialization
                    | GameOnGoing OnlineGameStatus
-                   | EndingGame
+                   | GameEnded
                    | ShuttingDown
                    | NetworkFailure NetworkFailureType
                    deriving Show

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -1,0 +1,119 @@
+
+{-|
+  Module      : Network
+  Description : Couche réseau d'Habanga
+  Copyright   : (c) Simon Désaulniers, 2025
+  License     : GPL-3
+
+  Maintainer  : sim.desaulniers@gmail.com
+
+  Ce module définit les différents types de données et
+  fonctions nécessaires à l'échange en multijoueur avec
+  plusieurs joueurs.
+-}
+
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Network ( networkLoop
+               ) where
+
+import GHC.Generics
+
+import Data.Char
+import qualified Data.ByteString as BS
+import Data.Default
+
+import Codec.Serialise
+
+import Control.Concurrent
+import Control.Concurrent.STM
+import Control.Monad.Trans
+import Control.Monad.Reader
+import Control.Lens
+
+import OpenDHT.Value
+import OpenDHT.Types
+import OpenDHT.InfoHash
+import OpenDHT.DhtRunner ( DhtRunnerM
+                         , DhtRunnerConfig
+                         , ValueCallback
+                         , runDhtRunnerM
+                         , proxyServer
+                         )
+import qualified OpenDHT.DhtRunner as DhtRunner
+
+import GameState
+
+_DEFAULT_BOOTSTRAP_ADDR_ :: String
+_DEFAULT_BOOTSTRAP_ADDR_  = "bootstrap.jami.net"
+
+_DEFAULT_BOOTSTRAP_PORT_ :: String
+_DEFAULT_BOOTSTRAP_PORT_  = "4222"
+
+opendhtWrongValueCtorError :: String -> String
+opendhtWrongValueCtorError = (<>) "Network: la fonction de rappel (listen) a retourné le type de valeur inattendu "
+
+data HabangaPacketType = GameAnnounce
+  deriving (Generic, Show)
+data HabangaPacket = HabangaPacket { _senderID   :: String
+                                   , _packetType :: HabangaPacketType
+                                   }
+  deriving Generic
+
+instance Serialise HabangaPacketType
+instance Serialise HabangaPacket
+
+listenForPlayerConnectionCb :: ValueCallback
+listenForPlayerConnectionCb (InputValue {})  _       = error $ opendhtWrongValueCtorError "InputValue"
+listenForPlayerConnectionCb (MetaValue {})   _       = error $ opendhtWrongValueCtorError "MetaValue"
+listenForPlayerConnectionCb (StoredValue {}) expired = undefined
+
+announceGame :: GameCode -> TVar GameState -> DhtRunnerM Dht ()
+announceGame gc gsTV = do
+  myHash <- DhtRunner.getNodeIdHash
+  gcHash <- liftIO $ unDht $ infoHashFromString gc
+  let
+    packet            = HabangaPacket { _senderID   = show myHash
+                                      , _packetType = GameAnnounce
+                                      }
+    gameAnnounceValue = InputValue { _valueData     = BS.toStrict $ serialise packet
+                                   , _valueUserType = show GameAnnounce
+                                   }
+    onDone False gs = gs & networkStatus .~ GameConnectionFail
+    onDone True gs  = gs & networkStatus .~ AwaitingConnection
+    doneCb success  = atomically $ modifyTVar gsTV $ onDone success
+  void $ DhtRunner.put gcHash gameAnnounceValue doneCb True
+
+shutdownCb :: IO ()
+shutdownCb  = return ()
+
+initializeDHT :: DhtRunnerConfig -> DhtRunnerM Dht ()
+initializeDHT dhtRconf = do
+  DhtRunner.runConfig 0 dhtRconf
+  when (all isSpace $ dhtRconf^.proxyServer) $
+    DhtRunner.bootstrap _DEFAULT_BOOTSTRAP_ADDR_ _DEFAULT_BOOTSTRAP_PORT_
+
+-- TODO: annuler le put permanent quand les joueurs sont tous connectés (usertype=GameAnnounce)
+handleNetworkStatus :: NetworkStatus -> DhtRunnerM Dht Bool
+handleNetworkStatus ShuttingDown = return False
+handleNetworkStatus status       = handle status >> return True
+  where
+    handle _ = undefined
+
+networkLoop :: (MonadIO m, MonadReader (TVar GameState) m) => GameCode -> DhtRunnerConfig -> m ()
+networkLoop gc dhtRconf = ask >>= \ gsTV -> liftIO $ runDhtRunnerM shutdownCb $ do
+  let
+    loop False = return ()
+    loop True  = do
+      gs <- liftIO $ do
+        threadDelay 500000
+        readTVarIO gsTV
+      b  <- handleNetworkStatus (gs^?!networkStatus)
+      loop b
+  initializeDHT dhtRconf
+  announceGame gc gsTV
+  loop True
+
+--  vim: set sts=2 ts=2 sw=2 tw=120 et :
+

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -221,7 +221,8 @@ handleNetworkStatus gsTV status    = handleNS status >> return True
       requestToJoinGame (gs^?!gameSettings.gameCode) (gs^.myName) gsTV
     handleNS (Request GameAnnounce) = do
       gs <- liftIO $ readTVarIO gsTV
-      liftIO$ atomically $ modifyTVar gsTV (playersIdentities .~ Map.fromList [(gs^.myID, gs^.myName)])
+      liftIO $ atomically $ modifyTVar gsTV $ \ gs' -> gs' & gameHostID        .~ gs' ^. myID
+                                                           & playersIdentities .~ Map.fromList [(gs'^.myID, gs'^.myName)]
       void $ announceGame (gs^?!gameSettings) gsTV
     handleNS (NetworkFailure (GameAnnouncementFailure msg)) = undefined -- TODO: annuler tous les puts/listen
     handleNS _ = return ()

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -161,8 +161,8 @@ gameJoinRequestCb myId gsTV (StoredValue d _ _ _ utype) False
           | not (Map.member myId' playersIds) = NetworkFailure $ GameJoinRequestFailure ourIdNotFoundFailureMsg
           | not (Map.member sId' playersIds)  = NetworkFailure $ GameJoinRequestFailure hostIdNotFoundFairureMsg
           | otherwise                         = case currentNetworkStatus of
-            GameInitialization -> currentNetworkStatus
-            _                  -> newNetworkStatusIfNotFail SetupPhaseDone gs
+            SetupPhaseDone -> currentNetworkStatus
+            _              -> newNetworkStatusIfNotFail SetupPhaseDone gs
     treatPacket (HabangaPacket sId GameJoinRequestAccepted) gs = (True, gsWithGameHostID)
       where
         sId'             = take _MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ sId

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -127,7 +127,7 @@ shareGameSetup gsTV = liftIO (readTVarIO gsTV) >>= \ gs -> do
                                       }
     onDone False gs' = gs' & networkStatus .~ newNetworkStatusIfNotFail failure gs'
       where
-        failure = NetworkFailure (GameJoinRequestFailure "network: échec de l'envoi d'une requête pour partager la config de la partie.")
+        failure = NetworkFailure (ShareGameSetupFailure "network: échec de l'envoi d'une requête pour partager la config de la partie.")
     onDone _ gs'     = gs'
     doneCb success  = atomically $ modifyTVar gsTV $ onDone success
   liftIO $ atomically $ modifyTVar gsTV $ \ gs' -> gs' & networkStatus .~ newNetworkStatusIfNotFail SetupPhaseDone gs'
@@ -158,8 +158,8 @@ gameJoinRequestCb myId gsTV (StoredValue d _ _ _ utype) False
                                   & gameSettings . numberOfPlayers .~ length playersIds
                                   & networkStatus                  .~ networkStatus'
         networkStatus'
-          | not (Map.member myId' playersIds) = NetworkFailure $ GameInitialSetupFailure ourIdNotFoundFailureMsg
-          | not (Map.member sId' playersIds)  = NetworkFailure $ GameInitialSetupFailure hostIdNotFoundFairureMsg
+          | not (Map.member myId' playersIds) = NetworkFailure $ GameJoinRequestFailure ourIdNotFoundFailureMsg
+          | not (Map.member sId' playersIds)  = NetworkFailure $ GameJoinRequestFailure hostIdNotFoundFairureMsg
           | otherwise                         = case currentNetworkStatus of
             GameInitialization -> currentNetworkStatus
             _                  -> newNetworkStatusIfNotFail SetupPhaseDone gs

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -221,6 +221,7 @@ handleNetworkStatus gsTV status    = handleNS status >> return True
       requestToJoinGame (gs^?!gameSettings.gameCode) (gs^.myName) gsTV
     handleNS (Request GameAnnounce) = do
       gs <- liftIO $ readTVarIO gsTV
+      liftIO$ atomically $ modifyTVar gsTV (playersIdentities .~ Map.fromList [(gs^.myID, gs^.myName)])
       void $ announceGame (gs^?!gameSettings) gsTV
     handleNS (NetworkFailure (GameAnnouncementFailure msg)) = undefined -- TODO: annuler tous les puts/listen
     handleNS _ = return ()

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -275,7 +275,7 @@ handleNetworkStatus gsTV status    = handleNS status >> return True
         & networkStatus .~ AwaitingRequest
         & myID          .~ gs ^. myID
         & myName        .~ gs ^. myName
-    handleNS (NetworkFailure (GameAnnouncementFailure msg)) = clearPendingDhtOps
+    handleNS (NetworkFailure (GameAnnouncementFailure _)) = clearPendingDhtOps
     handleNS _ = return ()
 
 loop :: (MonadIO m, MonadReader (TVar GameState) m) => DhtRunnerConfig -> m ()

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -16,20 +16,17 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE LambdaCase #-}
 
 module Network ( loop
                ) where
 
 import GHC.Generics
 
-import Data.Maybe
 import Data.Word
 import Data.Default
 import Data.Data
 import Data.Char
 import Data.Map (Map)
-import qualified Data.List as List
 import qualified Data.Map as Map
 import qualified Data.ByteString as BS
 
@@ -57,7 +54,7 @@ import OpenDHT.DhtRunner ( DhtRunnerM
 import qualified OpenDHT.DhtRunner as DhtRunner
 
 import Cards
-import GameState
+import NetworkState
 
 -- Le temps de pause de la boucle en microsecondes
 _MAIN_LOOP_THREAD_SLEEP_TIME_ :: Int
@@ -121,35 +118,35 @@ clearListenRequests = do
     forM_ tokens $ \ t ->
       runMaybeT (DhtRunner.cancelListen h t)
 
-newNetworkStatusSafe :: NetworkStatus -> GameState -> NetworkStatus
-newNetworkStatusSafe ns gs = let currentNetworkStatus = gs ^?! networkStatus in case currentNetworkStatus of
+newNetworkStatusSafe :: NetworkStatus -> NetworkState -> NetworkStatus
+newNetworkStatusSafe nStatus ns = let currentNetworkStatus = ns ^. status in case currentNetworkStatus of
   NetworkFailure {} -> currentNetworkStatus
   ShuttingDown      -> currentNetworkStatus
-  _                 -> ns
+  _                 -> nStatus
 
-playMyTurn :: Either Card Card -> TVar GameState -> DhtRunnerM Dht ()
-playMyTurn card gsTV = liftIO (readTVarIO gsTV) >>= \ gs -> do
-  gcHash <- liftIO $ unDht $ infoHashFromString $ gs ^. gameSettings . gameCode
+playMyTurn :: Either Card Card -> TVar NetworkState -> DhtRunnerM Dht ()
+playMyTurn card nsTV = liftIO (readTVarIO nsTV) >>= \ ns -> do
+  gcHash <- liftIO $ unDht $ infoHashFromString $ ns ^. gameSettings . gameCode
   let
-    packet          = HabangaPacket { _senderID = gs ^. myID
-                                    , _content  = PlayerTurn card (gs ^?! turnNumber + 1)
+    packet          = HabangaPacket { _senderID = ns ^. myID
+                                    , _content  = PlayerTurn card (ns ^?! turnNumber + 1)
                                     }
     playerTurnValue = InputValue { _valueData     = BS.toStrict $ serialise packet
                                  , _valueUserType = _PLAYER_TURN_UTYPE_
                                  }
-    onDone False gs' = gs' & networkStatus .~ newNetworkStatusSafe failure gs'
+    onDone False gs' = gs' & status .~ newNetworkStatusSafe failure gs'
       where
         failure = NetworkFailure (ShareGameSetupFailure "network: échec de l'envoi mon jeu pour ce tour.")
     onDone _ gs' = gs'
-    doneCb success  = atomically $ modifyTVar gsTV $ onDone success
-  liftIO $ atomically $ modifyTVar gsTV $ \ gs' -> gs' & networkStatus .~ newNetworkStatusSafe (GameOnGoing AwaitingOtherPlayerTurn) gs'
+    doneCb success  = atomically $ modifyTVar nsTV $ onDone success
+  liftIO $ atomically $ modifyTVar nsTV $ \ gs' -> gs' & status .~ newNetworkStatusSafe (GameOnGoing AwaitingOtherPlayerTurn) gs'
   void $ DhtRunner.put gcHash playerTurnValue doneCb False
 
-gameOnGoingCb :: TVar GameState -> ValueCallback
+gameOnGoingCb :: TVar NetworkState -> ValueCallback
 gameOnGoingCb _    (InputValue {})             _    = error $ opendhtWrongValueCtorError "InputValue"
 gameOnGoingCb _    (MetaValue {})              _    = error $ opendhtWrongValueCtorError "MetaValue"
 gameOnGoingCb _    (StoredValue {})            True = return True
-gameOnGoingCb gsTV (StoredValue d _ _ _ utype) False
+gameOnGoingCb nsTV (StoredValue d _ _ _ utype) False
   | utype == _PLAYER_TURN_UTYPE_ = deserialiseAndTreatPacket
   | otherwise                    = return True
   where
@@ -157,44 +154,44 @@ gameOnGoingCb gsTV (StoredValue d _ _ _ utype) False
       eitherHabangaPacketOrFail <- try $ return $ deserialise $ BS.fromStrict d
       case eitherHabangaPacketOrFail of
         Left (DeserialiseFailure {}) -> return True
-        Right habangaPacket          -> atomically $ stateTVar gsTV $ treatPacket habangaPacket
-    treatPacket (HabangaPacket sId (PlayerTurn card tn)) gs
-      | sId == gs ^. myID = (True, gs)
+        Right habangaPacket          -> atomically $ stateTVar nsTV $ treatPacket habangaPacket
+    treatPacket (HabangaPacket sId (PlayerTurn card tn)) ns
+      | sId == ns ^. myID = (True, ns)
       | otherwise         = (True, gs')
       where
-        gs'                    = gs & gameTurns     .~ gameTurns'
-                                    & networkStatus .~ newNetworkStatusSafe networkStatus' gs
-        gameTurns'             = Map.insert tn card (gs^.gameTurns)
-        lastTurnNumber         = fromIntegral $ fst $ last $ consecutivePlayerTurns gs gameTurns'
-        isOurTurn              = lastTurnNumber `mod` (gs ^?! gameSettings . numberOfPlayers) == gs ^?! myPlayerRank
+        gs'                    = ns & gameTurns     .~ gameTurns'
+                                    & status .~ newNetworkStatusSafe networkStatus' ns
+        gameTurns'             = Map.insert tn card (ns^.gameTurns)
+        lastTurnNumber         = fromIntegral $ fst $ last $ consecutivePlayerTurns ns gameTurns'
+        isOurTurn              = lastTurnNumber `mod` (ns ^?! gameSettings . numberOfPlayers) == ns ^?! myPlayerRank
         networkStatus'
           | isOurTurn = GameOnGoing AwaitingPlayerTurn
-          | otherwise = gs ^?! networkStatus
-    treatPacket _ gs = (True, gs)
+          | otherwise = ns ^. status
+    treatPacket _ ns = (True, ns)
 
-shareGameSetup :: TVar GameState -> DhtRunnerM Dht ()
-shareGameSetup gsTV = liftIO (readTVarIO gsTV) >>= \ gs -> do
-  gcHash <- liftIO $ unDht $ infoHashFromString $ gs ^. gameSettings . gameCode
+shareGameSetup :: TVar NetworkState -> DhtRunnerM Dht ()
+shareGameSetup nsTV = liftIO (readTVarIO nsTV) >>= \ ns -> do
+  gcHash <- liftIO $ unDht $ infoHashFromString $ ns ^. gameSettings . gameCode
   let
-    packet               = HabangaPacket { _senderID = gs ^. myID
-                                         , _content  = GameSetup $ gs ^. playersIdentities
+    packet               = HabangaPacket { _senderID = ns ^. myID
+                                         , _content  = GameSetup $ ns ^. playersIdentities
                                          }
     gameJoinRequestValue = InputValue { _valueData     = BS.toStrict $ serialise packet
                                       , _valueUserType = _GAME_SETUP_UTYPE_
                                       }
-    onDone False gs' = gs' & networkStatus .~ newNetworkStatusSafe failure gs'
+    onDone False gs' = gs' & status .~ newNetworkStatusSafe failure gs'
       where
         failure = NetworkFailure (ShareGameSetupFailure "network: échec de l'envoi d'une requête pour partager la config de la partie.")
     onDone _ gs'     = gs'
-    doneCb success  = atomically $ modifyTVar gsTV $ onDone success
-  liftIO $ atomically $ modifyTVar gsTV $ \ gs' -> gs' & networkStatus .~ newNetworkStatusSafe SetupPhaseDone gs'
+    doneCb success  = atomically $ modifyTVar nsTV $ onDone success
+  liftIO $ atomically $ modifyTVar nsTV $ \ gs' -> gs' & status .~ newNetworkStatusSafe SetupPhaseDone gs'
   void $ DhtRunner.put gcHash gameJoinRequestValue doneCb False
 
-gameJoinRequestCb :: String -> TVar GameState -> ValueCallback
+gameJoinRequestCb :: String -> TVar NetworkState -> ValueCallback
 gameJoinRequestCb _    _    (InputValue {})             _    = error $ opendhtWrongValueCtorError "InputValue"
 gameJoinRequestCb _    _    (MetaValue {})              _    = error $ opendhtWrongValueCtorError "MetaValue"
 gameJoinRequestCb _    _    (StoredValue {})            True = return True
-gameJoinRequestCb myId gsTV (StoredValue d _ _ _ utype) False
+gameJoinRequestCb myId nsTV (StoredValue d _ _ _ utype) False
   | utype == _GAME_JOIN_REQUEST_ACCEPTED_UTYPE_ = deserialiseAndTreatPacket
   | utype == _GAME_SETUP_UTYPE_                 = deserialiseAndTreatPacket
   | otherwise                                   = return True
@@ -203,36 +200,36 @@ gameJoinRequestCb myId gsTV (StoredValue d _ _ _ utype) False
       eitherHabangaPacketOrFail <- try $ return $ deserialise $ BS.fromStrict d
       case eitherHabangaPacketOrFail of
         Left (DeserialiseFailure {}) -> return True
-        Right habangaPacket          -> atomically $ stateTVar gsTV $ treatPacket habangaPacket
-    treatPacket (HabangaPacket sId (GameSetup playersIds)) gs = (True, gs')
+        Right habangaPacket          -> atomically $ stateTVar nsTV $ treatPacket habangaPacket
+    treatPacket (HabangaPacket sId (GameSetup playersIds)) ns = (True, gs')
       where
         sId'                 = take _MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ sId
         myId'                = take _MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ myId
-        currentNetworkStatus = gs ^?! networkStatus
-        gs'                  = gs
+        currentNetworkStatus = ns ^. status
+        gs'                  = ns
                                   & playersIdentities              .~ playersIds
                                   & gameHostID                     .~ sId'
                                   & gameSettings . numberOfPlayers .~ length playersIds
-                                  & networkStatus                  .~ networkStatus'
+                                  & status                         .~ networkStatus'
         networkStatus'
           | not (Map.member myId' playersIds) = NetworkFailure $ GameJoinRequestFailure ourIdNotFoundFailureMsg
           | not (Map.member sId' playersIds)  = NetworkFailure $ GameJoinRequestFailure hostIdNotFoundFairureMsg
           | otherwise                         = case currentNetworkStatus of
             SetupPhaseDone -> currentNetworkStatus
-            _              -> newNetworkStatusSafe SetupPhaseDone gs
-    treatPacket (HabangaPacket sId GameJoinRequestAccepted) gs = (True, gsWithGameHostID)
+            _              -> newNetworkStatusSafe SetupPhaseDone ns
+    treatPacket (HabangaPacket sId GameJoinRequestAccepted) ns = (True, gsWithGameHostID)
       where
         sId'             = take _MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ sId
-        gsWithGameHostID = gs
+        gsWithGameHostID = ns
                               & gameHostID    .~ sId'
-                              & networkStatus .~ newNetworkStatusSafe (AwaitingEvent GameStarted) gs
-    treatPacket _ gs = (True, gs)
+                              & status .~ newNetworkStatusSafe (AwaitingEvent GameStarted) ns
+    treatPacket _ ns = (True, ns)
     ourIdNotFoundFailureMsg  = "network: on a reçu un paquet GameSetup, mais notre ID n'était pas dans la liste."
     hostIdNotFoundFairureMsg = "network: on a reçu un paquet GameSetup, mais l'ID de l'hôte n'était pas dans la liste."
 
 
-requestToJoinGame :: GameCode -> String -> TVar GameState -> DhtRunnerM Dht ()
-requestToJoinGame gc playerName gsTV = liftIO (readTVarIO gsTV) >>= \ initialGameState -> do
+requestToJoinGame :: GameCode -> String -> TVar NetworkState -> DhtRunnerM Dht ()
+requestToJoinGame gc playerName nsTV = liftIO (readTVarIO nsTV) >>= \ initialGameState -> do
   gcHash <- liftIO $ unDht $ infoHashFromString gc
   let
     packet               = HabangaPacket { _senderID = initialGameState ^. myID
@@ -241,47 +238,47 @@ requestToJoinGame gc playerName gsTV = liftIO (readTVarIO gsTV) >>= \ initialGam
     gameJoinRequestValue = InputValue { _valueData     = BS.toStrict $ serialise packet
                                       , _valueUserType = _GAME_JOIN_REQUEST_UTYPE_
                                       }
-    onDone False gs = gs & networkStatus .~ newNetworkStatusSafe failure gs
+    onDone False ns = ns & status .~ newNetworkStatusSafe failure ns
       where
         failure = NetworkFailure (GameJoinRequestFailure "network: échec de l'envoi d'une requête pour joindre la partie.")
-    onDone _ gs     = gs
-    doneCb success  = atomically $ modifyTVar gsTV $ onDone success
-  liftIO $ atomically $ modifyTVar gsTV $ \ gs -> gs & networkStatus .~ newNetworkStatusSafe (AwaitingEvent Connection) gs
+    onDone _ ns     = ns
+    doneCb success  = atomically $ modifyTVar nsTV $ onDone success
+  liftIO $ atomically $ modifyTVar nsTV $ \ ns -> ns & status .~ newNetworkStatusSafe (AwaitingEvent Connection) ns
   void $ DhtRunner.put gcHash gameJoinRequestValue doneCb False
-  void $ DhtRunner.listen gcHash (gameJoinRequestCb (initialGameState ^. myID) gsTV) shutdownCb
+  void $ DhtRunner.listen gcHash (gameJoinRequestCb (initialGameState ^. myID) nsTV) shutdownCb
 
-gameAnnounceCb :: Int -> TVar GameState -> ValueCallback
+gameAnnounceCb :: Int -> TVar NetworkState -> ValueCallback
 gameAnnounceCb _                  _    (InputValue {})             _    = error $ opendhtWrongValueCtorError "InputValue"
 gameAnnounceCb _                  _    (MetaValue {})              _    = error $ opendhtWrongValueCtorError "MetaValue"
 gameAnnounceCb _                  _    (StoredValue {})            True = return True
-gameAnnounceCb maxNumberOfPlayers gsTV (StoredValue d _ _ _ utype) False
+gameAnnounceCb maxNumberOfPlayers nsTV (StoredValue d _ _ _ utype) False
   | utype == _GAME_JOIN_REQUEST_UTYPE_ = deserialiseAndTreatPacket
   | otherwise                          = return True
   where
-    treatPacket (HabangaPacket sId (GameJoinRequest pName)) gs =
+    treatPacket (HabangaPacket sId (GameJoinRequest pName)) ns =
       let sId' = take _MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ sId
-          gs'  = gs
+          gs'  = ns
                     & playersIdentities %~ Map.insert sId' pName
-                    & networkStatus     .~ newNetworkStatusSafe networkStatus' gs
+                    & status            .~ newNetworkStatusSafe networkStatus' ns
           networkStatus'
             | not stillHasSpaceForOtherPlayers = SharingGameSetup
-            | otherwise                        = gs ^?! networkStatus
+            | otherwise                        = ns ^. status
           stillHasSpaceForOtherPlayers = length (gs'^.playersIdentities) < maxNumberOfPlayers
-       in case Map.lookup sId' (gs^.playersIdentities) of
-            Just _  -> (True, gs)
+       in case Map.lookup sId' (ns^.playersIdentities) of
+            Just _  -> (True, ns)
             Nothing -> (stillHasSpaceForOtherPlayers, gs')
-    treatPacket _ gs = (True, gs)
+    treatPacket _ ns = (True, ns)
 
     deserialiseAndTreatPacket = do
       eitherHabangaPacketOrFail <- try $ return $ deserialise $ BS.fromStrict d
       case eitherHabangaPacketOrFail of
         Left (DeserialiseFailure {}) -> return True
-        Right habangaPacket          -> atomically $ stateTVar gsTV $ \ gs ->
-          if length (gs^.playersIdentities) < maxNumberOfPlayers then treatPacket habangaPacket gs
-                                                                 else (False, gs)
+        Right habangaPacket          -> atomically $ stateTVar nsTV $ \ ns ->
+          if length (ns^.playersIdentities) < maxNumberOfPlayers then treatPacket habangaPacket ns
+                                                                 else (False, ns)
 
-announceGame :: OnlineGameSettings -> TVar GameState -> DhtRunnerM Dht OpToken
-announceGame (OnlineGameSettings gc maxNumberOfPlayers) gsTV = liftIO (readTVarIO gsTV) >>= \ initialGameState -> do
+announceGame :: OnlineGameSettings -> TVar NetworkState -> DhtRunnerM Dht OpToken
+announceGame (OnlineGameSettings gc maxNumberOfPlayers) nsTV = liftIO (readTVarIO nsTV) >>= \ initialGameState -> do
   gcHash <- liftIO $ unDht $ infoHashFromString gc
   let
     packet            = HabangaPacket { _senderID   = initialGameState ^. myID
@@ -290,14 +287,14 @@ announceGame (OnlineGameSettings gc maxNumberOfPlayers) gsTV = liftIO (readTVarI
     gameAnnounceValue = InputValue { _valueData     = BS.toStrict $ serialise packet
                                    , _valueUserType = _GAME_ANNOUNCEMENT_UTYPE_
                                    }
-    onDone False gs = gs & networkStatus .~ newNetworkStatusSafe failure gs
+    onDone False ns = ns & status .~ newNetworkStatusSafe failure ns
       where
         failure = NetworkFailure (GameAnnouncementFailure "network: échec de l'envoi du paquet d'annonce de la partie.")
-    onDone _ gs     = gs
-    doneCb success  = atomically $ modifyTVar gsTV $ onDone success
-  liftIO $ atomically $ modifyTVar gsTV $ \ gs -> gs & networkStatus .~ newNetworkStatusSafe (AwaitingEvent Connection) gs
+    onDone _ ns     = ns
+    doneCb success  = atomically $ modifyTVar nsTV $ onDone success
+  liftIO $ atomically $ modifyTVar nsTV $ \ ns -> ns & status .~ newNetworkStatusSafe (AwaitingEvent Connection) ns
   void $ DhtRunner.put gcHash gameAnnounceValue doneCb True
-  DhtRunner.listen gcHash (gameAnnounceCb maxNumberOfPlayers gsTV) shutdownCb
+  DhtRunner.listen gcHash (gameAnnounceCb maxNumberOfPlayers nsTV) shutdownCb
 
 initializeDHT :: DhtRunnerConfig -> DhtRunnerM Dht ()
 initializeDHT dhtRconf = do
@@ -305,73 +302,64 @@ initializeDHT dhtRconf = do
   when (all isSpace $ dhtRconf^.proxyServer) $
     DhtRunner.bootstrap _DEFAULT_BOOTSTRAP_ADDR_ _DEFAULT_BOOTSTRAP_PORT_
 
-handleNetworkStatus :: TVar GameState -> NetworkStatus -> DhtRunnerM Dht Bool
+handleNetworkStatus :: TVar NetworkState -> NetworkStatus -> DhtRunnerM Dht Bool
 handleNetworkStatus _ ShuttingDown = return False
-handleNetworkStatus gsTV status    = handleNS status >> return True
+handleNetworkStatus nsTV nStatus    = handleNS nStatus >> return True
   where
     clearPendingDhtOps = do
-      gs <- liftIO $ readTVarIO gsTV
-      gcHash <- liftIO $ unDht $ infoHashFromString $ gs ^. gameSettings . gameCode
+      ns <- liftIO $ readTVarIO nsTV
+      gcHash <- liftIO $ unDht $ infoHashFromString $ ns ^. gameSettings . gameCode
       clearPermanentPutRequests gcHash
       clearListenRequests
     handleNS (Request (JoinGame gc myname)) = do
-      liftIO $ atomically $ modifyTVar gsTV $ \ gs' -> gs' & gameSettings.gameCode .~ gc
+      liftIO $ atomically $ modifyTVar nsTV $ \ gs' -> gs' & gameSettings.gameCode .~ gc
                                                            & myName                .~ myname
-      requestToJoinGame gc myname gsTV
+      requestToJoinGame gc myname nsTV
     handleNS (Request (GameAnnounce theGameSettings myname)) = do
-      liftIO $ atomically $ modifyTVar gsTV $ \ gs' -> gs' & gameSettings      .~ theGameSettings
+      liftIO $ atomically $ modifyTVar nsTV $ \ gs' -> gs' & gameSettings      .~ theGameSettings
                                                            & gameHostID        .~ gs' ^. myID
                                                            & myName            .~ myname
                                                            & playersIdentities .~ Map.fromList [(gs'^.myID, myname)]
-      void $ announceGame theGameSettings gsTV
-    handleNS SharingGameSetup = shareGameSetup gsTV
+      void $ announceGame theGameSettings nsTV
+    handleNS SharingGameSetup = shareGameSetup nsTV
     handleNS SetupPhaseDone = do
       clearPendingDhtOps
-      liftIO $ atomically $ modifyTVar gsTV $ \ gs -> gs & networkStatus .~ newNetworkStatusSafe GameReadyForInitialization gs
-    handleNS (Request GameStart) = do
-      gs     <- liftIO $ readTVarIO gsTV
-      gcHash <- liftIO $ unDht $ infoHashFromString $ gs ^. gameSettings . gameCode
+      liftIO $ atomically $ modifyTVar nsTV $ \ ns -> ns & status .~ newNetworkStatusSafe GameReadyForInitialization ns
+    handleNS (Request (GameStart myRank)) = do
+      ns     <- liftIO $ readTVarIO nsTV
+      gcHash <- liftIO $ unDht $ infoHashFromString $ ns ^. gameSettings . gameCode
       let
-        myPlayerRank' = fromJust $ List.elemIndex (gs^.myName) $ map (view name) (gs ^. players)
         networkStatus'
-          | myPlayerRank' == 0 = GameOnGoing AwaitingPlayerTurn
-          | otherwise          = GameOnGoing AwaitingOtherPlayerTurn
-      liftIO $ atomically $ modifyTVar gsTV $ \ gs' -> gs'
-        & networkStatus .~ newNetworkStatusSafe networkStatus' gs'
-        & myPlayerRank  .~ myPlayerRank'
+          | myRank == 0 = GameOnGoing AwaitingPlayerTurn
+          | otherwise   = GameOnGoing AwaitingOtherPlayerTurn
+      liftIO $ atomically $ modifyTVar nsTV $ \ gs' -> gs'
+        & status .~ newNetworkStatusSafe networkStatus' gs'
+        & myPlayerRank  .~ myRank
         & turnNumber    .~ 0
-      void $ DhtRunner.listen gcHash (gameOnGoingCb gsTV) shutdownCb
-    handleNS (Request (PlayTurn card)) = liftIO (readTVarIO gsTV) >>= \ gs -> do
-      let
-        currentPlayer    = last (gs ^. players) -- on vient juste de jouer notre tour, donc on est rendu à la fin.
-        isMyTurn         = currentPlayer ^. name == gs ^. myName
-        revertStatus gs' = gs' & networkStatus .~ newNetworkStatusSafe (GameOnGoing AwaitingOtherPlayerTurn) gs'
-      if isMyTurn then playMyTurn card gsTV
-                  else liftIO $ atomically $ modifyTVar gsTV revertStatus
+      void $ DhtRunner.listen gcHash (gameOnGoingCb nsTV) shutdownCb
+    handleNS (Request (PlayTurn card)) = playMyTurn card nsTV
     handleNS (Request ResetNetwork) = do
       clearPendingDhtOps
-      liftIO $ atomically $ modifyTVar gsTV $ \ gs -> defaultOnlineGameState
-        & networkStatus .~ newNetworkStatusSafe AwaitingRequest gs
-        & myID          .~ gs ^. myID
-        & myName        .~ gs ^. myName
+      liftIO $ atomically $ modifyTVar nsTV $ \ ns -> def
+        & status .~ newNetworkStatusSafe AwaitingRequest ns
+        & myID          .~ ns ^. myID
+        & myName        .~ ns ^. myName
     handleNS _ = return ()
 
-loop :: (MonadIO m, MonadReader (TVar GameState) m) => DhtRunnerConfig -> m ()
-loop dhtRconf = ask >>= \ gsTV -> liftIO $ readTVarIO gsTV >>= \ case
-  OnlineGameState {} -> runDhtRunnerM shutdownCb $ do
-    let
-      innerLoop False = return ()
-      innerLoop True  = do
-        gs <- liftIO $ do
-          threadDelay _MAIN_LOOP_THREAD_SLEEP_TIME_
-          readTVarIO gsTV
-        b  <- handleNetworkStatus gsTV (gs^?!networkStatus)
-        innerLoop b
-    initializeDHT dhtRconf
-    myHash <- DhtRunner.getNodeIdHash
-    liftIO $ atomically $ modifyTVar gsTV (myID .~ take _MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ (show myHash))
-    innerLoop True
-  _ -> error "Network.loop: l'état du jeu passé n'était pas construit par OnlineGameState.."
+loop :: (MonadIO m, MonadReader (TVar NetworkState) m) => DhtRunnerConfig -> m ()
+loop dhtRconf = ask >>= \ nsTV -> liftIO $ runDhtRunnerM shutdownCb $ do
+  let
+    innerLoop False = return ()
+    innerLoop True  = do
+      ns <- liftIO $ do
+        threadDelay _MAIN_LOOP_THREAD_SLEEP_TIME_
+        readTVarIO nsTV
+      b  <- handleNetworkStatus nsTV (ns^.status)
+      innerLoop b
+  initializeDHT dhtRconf
+  myHash <- DhtRunner.getNodeIdHash
+  liftIO $ atomically $ modifyTVar nsTV (myID .~ take _MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ (show myHash))
+  innerLoop True
 
 --  vim: set sts=2 ts=2 sw=2 tw=120 et :
 

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -206,7 +206,7 @@ gameAnnounceCb maxNumberOfPlayers gsTV (StoredValue d _ _ _ utype) False
       eitherHabangaPacketOrFail <- try $ return $ deserialise $ BS.fromStrict d
       case eitherHabangaPacketOrFail of
         Left (DeserialiseFailure {}) -> return True
-        Right habangaPacket                     -> atomically $ stateTVar gsTV $ \ gs ->
+        Right habangaPacket          -> atomically $ stateTVar gsTV $ \ gs ->
           if length (gs^.playersIdentities) < maxNumberOfPlayers then treatPacket habangaPacket gs
                                                                  else (False, gs)
 

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -93,9 +93,10 @@ newNetworkStatusIfNotFail ns gs = let currentNetworkStatus = gs ^?! networkStatu
   _                 -> ns
 
 gameAnnounceCb :: Int -> TVar GameState -> ValueCallback
-gameAnnounceCb _ _    (InputValue {}) _ = error $ opendhtWrongValueCtorError "InputValue"
-gameAnnounceCb _ _    (MetaValue {})  _ = error $ opendhtWrongValueCtorError "MetaValue"
-gameAnnounceCb maxNumberOfPlayers gsTV (StoredValue d _ _ _ utype) _
+gameAnnounceCb _                  _    (InputValue {})             _    = error $ opendhtWrongValueCtorError "InputValue"
+gameAnnounceCb _                  _    (MetaValue {})              _    = error $ opendhtWrongValueCtorError "MetaValue"
+gameAnnounceCb _                  _    (StoredValue {})            True = return True
+gameAnnounceCb maxNumberOfPlayers gsTV (StoredValue d _ _ _ utype) False
   | utype == _GAME_JOIN_REQUEST_UTYPE_ = do
     let
       treatPacket (HabangaPacket sId (GameJoinRequest pName)) gs =

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -267,10 +267,10 @@ handleNetworkStatus gsTV status    = handleNS status >> return True
                                                            & myName            .~ myname
                                                            & playersIdentities .~ Map.fromList [(gs'^.myID, myname)]
       void $ announceGame theGameSettings gsTV
-    handleNS SharingGameSetup   = shareGameSetup gsTV
+    handleNS SharingGameSetup = shareGameSetup gsTV
     handleNS SetupPhaseDone = do
       clearPendingDhtOps
-      liftIO $ atomically $ modifyTVar gsTV $ networkStatus .~ GameInitialization
+      liftIO $ atomically $ modifyTVar gsTV $ \ gs -> gs & networkStatus .~ newNetworkStatusIfNotFail GameReadyForInitialization gs
     handleNS (Request ResetNetwork) = do
       clearPendingDhtOps
       liftIO $ atomically $ modifyTVar gsTV $ \ gs -> defaultOnlineGameState

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -267,9 +267,14 @@ handleNetworkStatus gsTV status    = handleNS status >> return True
       void $ announceGame (gs^?!gameSettings) gsTV
     handleNS SharingGameSetup   = shareGameSetup gsTV
     handleNS SetupPhaseDone = do
-      gs <- liftIO $ readTVarIO gsTV
       clearPendingDhtOps
       liftIO $ atomically $ modifyTVar gsTV $ networkStatus .~ GameInitialization
+    handleNS (Request ResetNetwork) = do
+      clearPendingDhtOps
+      liftIO $ atomically $ modifyTVar gsTV $ \ gs -> defaultOnlineGameState
+        & networkStatus .~ AwaitingRequest
+        & myID          .~ gs ^. myID
+        & myName        .~ gs ^. myName
     handleNS (NetworkFailure (GameAnnouncementFailure msg)) = clearPendingDhtOps
     handleNS _ = return ()
 

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -67,7 +67,6 @@ opendhtWrongValueCtorError = (<>) "Network: la fonction de rappel (listen) a ret
 
 data HabangaPacketContent = GameAnnouncement
                           | GameJoinRequest { _playerName :: String
-                                            , _playerID   :: String
                                             }
   deriving (Generic, Data, Show)
 data HabangaPacket = HabangaPacket { _senderID   :: String
@@ -82,7 +81,7 @@ _GAME_ANNOUNCEMENT_UTYPE_ :: String
 _GAME_ANNOUNCEMENT_UTYPE_ = show $ toConstr GameAnnouncement
 
 _GAME_JOIN_REQUEST_UTYPE_ :: String
-_GAME_JOIN_REQUEST_UTYPE_ = show $ toConstr $ GameJoinRequest "" ""
+_GAME_JOIN_REQUEST_UTYPE_ = show $ toConstr $ GameJoinRequest ""
 
 -- TODO:
 shutdownCb :: ShutdownCallback
@@ -94,7 +93,7 @@ playerConnectionCb _ _    (MetaValue {})  _ = error $ opendhtWrongValueCtorError
 playerConnectionCb maxNumberOfPlayers gsTV (StoredValue d _ _ _ utype) _
   | utype == _GAME_JOIN_REQUEST_UTYPE_ = do
     let
-      treatPacket (HabangaPacket _ (GameJoinRequest pName pId)) gs =
+      treatPacket (HabangaPacket pId (GameJoinRequest pName)) gs =
         let pId'                     = take _MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ pId
             stateWithNewPlayer       = gs & playersIdentities %~ Map.insert pId' pName
             stillSpaceAfterNewPlayer = length (stateWithNewPlayer^.playersIdentities) < maxNumberOfPlayers

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -110,8 +110,8 @@ gameAnnounceCb maxNumberOfPlayers gsTV (StoredValue d _ _ _ utype) _
                                                                else (False, gs)
   | otherwise = return True
 
-announceGame :: GameSettings -> TVar GameState -> DhtRunnerM Dht OpToken
-announceGame (GameSettings gc maxNumberOfPlayers) gsTV = do
+announceGame :: OnlineGameSettings -> TVar GameState -> DhtRunnerM Dht OpToken
+announceGame (OnlineGameSettings gc maxNumberOfPlayers) gsTV = do
   myHash <- DhtRunner.getNodeIdHash
   gcHash <- liftIO $ unDht $ infoHashFromString gc
   let

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -87,10 +87,10 @@ _GAME_JOIN_REQUEST_UTYPE_ = show $ toConstr $ GameJoinRequest ""
 shutdownCb :: ShutdownCallback
 shutdownCb = return ()
 
-playerConnectionCb :: Int -> TVar GameState -> ValueCallback
-playerConnectionCb _ _    (InputValue {}) _ = error $ opendhtWrongValueCtorError "InputValue"
-playerConnectionCb _ _    (MetaValue {})  _ = error $ opendhtWrongValueCtorError "MetaValue"
-playerConnectionCb maxNumberOfPlayers gsTV (StoredValue d _ _ _ utype) _
+gameAnnounceCb :: Int -> TVar GameState -> ValueCallback
+gameAnnounceCb _ _    (InputValue {}) _ = error $ opendhtWrongValueCtorError "InputValue"
+gameAnnounceCb _ _    (MetaValue {})  _ = error $ opendhtWrongValueCtorError "MetaValue"
+gameAnnounceCb maxNumberOfPlayers gsTV (StoredValue d _ _ _ utype) _
   | utype == _GAME_JOIN_REQUEST_UTYPE_ = do
     let
       treatPacket (HabangaPacket pId (GameJoinRequest pName)) gs =
@@ -126,7 +126,7 @@ announceGame (GameSettings gc maxNumberOfPlayers) gsTV = do
     doneCb success  = atomically $ modifyTVar gsTV $ onDone success
   liftIO $ atomically $ modifyTVar gsTV (networkStatus .~ AwaitingConnection)
   void $ DhtRunner.put gcHash gameAnnounceValue doneCb True
-  DhtRunner.listen gcHash (playerConnectionCb maxNumberOfPlayers gsTV) shutdownCb
+  DhtRunner.listen gcHash (gameAnnounceCb maxNumberOfPlayers gsTV) shutdownCb
 
 initializeDHT :: DhtRunnerConfig -> DhtRunnerM Dht ()
 initializeDHT dhtRconf = do

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -270,7 +270,7 @@ handleNetworkStatus gsTV status    = handleNS status >> return True
       gs <- liftIO $ readTVarIO gsTV
       clearPendingDhtOps
       liftIO $ atomically $ modifyTVar gsTV $ networkStatus .~ GameInitialization
-    handleNS (NetworkFailure (GameAnnouncementFailure msg)) = undefined -- TODO: annuler tous les puts/listen
+    handleNS (NetworkFailure (GameAnnouncementFailure msg)) = clearPendingDhtOps
     handleNS _ = return ()
 
 loop :: (MonadIO m, MonadReader (TVar GameState) m) => DhtRunnerConfig -> m ()

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -277,7 +277,6 @@ handleNetworkStatus gsTV status    = handleNS status >> return True
         & networkStatus .~ AwaitingRequest
         & myID          .~ gs ^. myID
         & myName        .~ gs ^. myName
-    handleNS (NetworkFailure (GameAnnouncementFailure _)) = clearPendingDhtOps
     handleNS _ = return ()
 
 loop :: (MonadIO m, MonadReader (TVar GameState) m) => DhtRunnerConfig -> m ()

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -205,9 +205,9 @@ gameAnnounceCb maxNumberOfPlayers gsTV (StoredValue d _ _ _ utype) False
       let sId' = take _MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ sId
           gs'  = gs
                     & playersIdentities %~ Map.insert sId' pName
-                    & networkStatus     .~ networkStatus'
+                    & networkStatus     .~ newNetworkStatusIfNotFail networkStatus' gs
           networkStatus'
-            | not stillHasSpaceForOtherPlayers = newNetworkStatusIfNotFail SharingGameSetup gs
+            | not stillHasSpaceForOtherPlayers = SharingGameSetup
             | otherwise                        = gs ^?! networkStatus
           stillHasSpaceForOtherPlayers = length (gs'^.playersIdentities) < maxNumberOfPlayers
        in case Map.lookup sId' (gs^.playersIdentities) of
@@ -274,7 +274,7 @@ handleNetworkStatus gsTV status    = handleNS status >> return True
     handleNS (Request ResetNetwork) = do
       clearPendingDhtOps
       liftIO $ atomically $ modifyTVar gsTV $ \ gs -> defaultOnlineGameState
-        & networkStatus .~ AwaitingRequest
+        & networkStatus .~ newNetworkStatusIfNotFail AwaitingRequest gs
         & myID          .~ gs ^. myID
         & myName        .~ gs ^. myName
     handleNS _ = return ()

--- a/src/core/NetworkState.hs
+++ b/src/core/NetworkState.hs
@@ -1,0 +1,108 @@
+
+{-# LANGUAGE TemplateHaskell #-}
+
+module NetworkState where
+
+import Data.Word
+import Data.Map (Map)
+import qualified Data.Map as Map
+import Data.Default
+
+import Control.Lens
+
+import Cards
+
+type GameCode = String
+
+type OnlinePlayerID = String
+type OnlinePlayerName = String
+
+data NetworkFailureType = GameAnnouncementFailure String
+                        | GameJoinRequestFailure String
+                        | ShareGameSetupFailure String
+                        deriving Show
+data OnlineGameStatus = AwaitingPlayerTurn
+                      | AwaitingOtherPlayerTurn
+                      deriving Show
+data NetworkRequest = GameAnnounce OnlineGameSettings String
+                    | JoinGame GameCode String
+                    | GameStart Int
+                    | PlayTurn (Either Card Card)
+                    | ResetNetwork
+                    deriving Show
+data NetworkEvent = Connection
+                  | GameStarted
+                  deriving Show
+data NetworkStatus = AwaitingRequest
+                   | AwaitingEvent NetworkEvent
+                   | Request NetworkRequest
+                   | SharingGameSetup
+                   | SetupPhaseDone
+                   | GameReadyForInitialization
+                   | GameOnGoing OnlineGameStatus
+                   | GameEnded
+                   | ShuttingDown
+                   | NetworkFailure NetworkFailureType
+                   deriving Show
+
+data OnlineGameSettings = OnlineGameSettings { _gameCode        :: GameCode
+                                             , _numberOfPlayers :: Int
+                                             }
+                                             deriving Show
+makeLenses ''OnlineGameSettings
+
+data NetworkState = NetworkState { _gameTurns         :: Map Word16 (Either Card Card)
+                                 , _playersIdentities :: Map OnlinePlayerID OnlinePlayerName
+                                 , _status            :: NetworkStatus
+                                 , _gameSettings      :: OnlineGameSettings
+                                 , _gameHostID        :: String
+                                 , _turnNumber        :: Word16
+                                 , _myID              :: String
+                                 , _myName            :: String
+                                 , _myPlayerRank      :: Int
+                                 }
+makeLenses ''NetworkState
+
+instance Default NetworkState where
+  def = NetworkState { _gameTurns         =  Map.empty
+                     , _playersIdentities =  mempty
+                     , _status            =  AwaitingRequest
+                     , _gameSettings      =  OnlineGameSettings [] 0
+                     , _gameHostID        =  ""
+                     , _turnNumber        =  0
+                     , _myID              =  ""
+                     , _myName            =  ""
+                     , _myPlayerRank      =  0
+                     }
+
+instance Show NetworkState where
+  show ns = unlines [ "GameTurns:"
+                    , "    " <> show (Map.toList $ ns ^. gameTurns)
+                    , "Player IDs:"
+                    , "    " <> show (Map.toList (ns ^. playersIdentities))
+                    , "NetworkStatus: "  <> show (ns ^. status)
+                    , "GameSettings:"
+                    , "    " <> " GameCode:        " <> ns ^. gameSettings . gameCode
+                    , "    " <> " NumberOfPlayers: " <> show (ns ^. gameSettings . numberOfPlayers)
+                    , "GameHostID:   " <> ns ^. gameHostID
+                    , "MyID:         " <> ns ^. myID
+                    , "MyName:       " <> ns ^. myName
+                    , "MyPlayerRank: " <> show (ns ^. myPlayerRank)
+                    ]
+
+_MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ :: Int
+_MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ = 6
+
+splitAtMissingTurn :: NetworkState -> Map Word16 (Either Card Card) -> ([(Word16, Either Card Card)], [(Word16, Either Card Card)])
+splitAtMissingTurn ns gameTurns' = (consecutivePlayerTurns', rest)
+  where
+    rest = map snd $ dropWhile (uncurry (==)) $ zip (Map.toList gameTurns') consecutivePlayerTurns'
+    consecutivePlayerTurns' = consecutivePlayerTurns ns gameTurns'
+
+consecutivePlayerTurns :: NetworkState -> Map Word16 (Either Card Card) -> [(Word16, Either Card Card)]
+consecutivePlayerTurns ns gameTurns' = map fst $ takeWhile turnIsSubsequent $ zip (Map.toList gameTurns') [ns^.turnNumber..]
+  where
+    turnIsSubsequent ((t',_), t) = t' == t + 1
+
+--  vim: set sts=2 ts=2 sw=2 tw=120 et :
+

--- a/src/core/Random.hs
+++ b/src/core/Random.hs
@@ -1,0 +1,26 @@
+
+module Random where
+
+import Data.Functor
+
+import Control.Monad.State
+
+import System.Random
+
+
+shuffle :: [a] -> IO [a]
+shuffle as = getStdGen <&> deterministiclyShuffle as
+
+deterministiclyShuffle :: RandomGen gen => [a] -> gen -> [a]
+deterministiclyShuffle es gen = flip evalState (es, gen) $ replicateM (length es) $ do
+  (l, gen') <- get
+  let (s, gen'') = random gen'
+      r          = s `mod` length l
+  case splitAt r l of
+    (beg, c:end) -> do
+      put (beg ++ end, gen'')
+      return c
+    (_, []) -> error "shuffle: la liste était vide. Ceci n'aurait pas dû se produire..."
+
+--  vim: set sts=2 ts=2 sw=2 tw=120 et :
+

--- a/src/tools/node/Main.hs
+++ b/src/tools/node/Main.hs
@@ -98,13 +98,15 @@ executeCmd = do
           -- TODO: ne pas utiliser gameSettings, mais passer directement gamecode à (Request GameAnnounce ...)
           & gameSettings.gameCode        .~ gc
       _ -> return ()
+    resetNetwork = liftIO $ atomically $ modifyTVar gsTV $ networkStatus .~ Request ResetNetwork
     printGameState = do
       gs <- liftIO $ readTVarIO gsTV
       logText %= (<> lines (show gs))
     exec
-      | cmd == "aide"                            = focusRing %= F.focusSetCurrent HelpBox
+      | cmd == "aide"                           = focusRing %= F.focusSetCurrent HelpBox
       | cmd `elem` [ "ag",  "announceGame"    ] = announceGame
       | cmd `elem` [ "rj",  "requestJoinGame" ] = requestJoinGame
+      | cmd `elem` [ "rs",  "resetNetwork"    ] = resetNetwork
       | cmd `elem` [ "pgs", "printGameState"  ] = printGameState
       | cmd `elem` [ "cl",  "clearLog"        ] = clearLog
       | cmd `elem` [ "q",   "quit"            ] = M.halt
@@ -159,6 +161,10 @@ drawUI ns = helpBox <> [mainUI]
                        , "requestJoinGame {code} {nomJoueur}"
                        , "  Demande d'accéder à la partie en tant que {nomJoueur}"
                        , "  en utilisant le code {code}."
+                       , ""
+                       , "rs"
+                       , "resetNetwork"
+                       , "  Réinitialisation du réseau et de l'état du jeu."
                        , ""
                        , "pgs"
                        , "printGameState"

--- a/src/tools/node/Main.hs
+++ b/src/tools/node/Main.hs
@@ -1,0 +1,201 @@
+
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE DeriveDataTypeable #-}
+
+module Main where
+
+import Data.Default
+import Data.Maybe
+
+import Text.Read
+
+import Control.Monad
+import Control.Monad.Reader
+import Control.Monad.Trans
+import Control.Lens
+import Control.Concurrent
+import Control.Concurrent.STM
+
+import Brick.AttrMap
+import Brick.Types ( BrickEvent
+                   , EventM
+                   , Widget
+                   )
+import qualified Brick.Types as T
+import Brick.Widgets.Core ( viewport
+                          , hLimit
+                          , vLimit
+                          , str
+                          , vBox
+                          , (<+>)
+                          )
+import qualified Brick.Widgets.Edit as E
+import qualified Brick.Widgets.Border as B
+import qualified Brick.Widgets.Center as C
+import qualified Brick.Main as M
+import qualified Brick.Focus as F
+
+import Graphics.Vty (defAttr)
+import qualified Graphics.Vty as V
+
+import Network
+import GameState
+
+data AppFocus = Input
+              | Log
+              | HelpBox
+  deriving (Ord, Show, Eq, Enum, Bounded)
+data NodeState = NodeState { _focusRing   :: F.FocusRing AppFocus
+                           , _inputEditor :: E.Editor String AppFocus
+                           , _logText     :: [String]
+                           , _gameStateTV :: TVar GameState
+                           }
+makeLenses ''NodeState
+
+clearLog :: EventM AppFocus NodeState ()
+clearLog = logText .= [ ]
+
+clearEditorInputText :: EventM AppFocus NodeState ()
+clearEditorInputText = inputEditor .= E.editor Input Nothing ""
+
+logViewportScroll :: M.ViewportScroll AppFocus
+logViewportScroll = M.viewportScroll Log
+
+executeCmd :: EventM AppFocus NodeState ()
+executeCmd = do
+  ie   <- use inputEditor
+  gsTV <- use gameStateTV
+  let
+    cmdline     = head $ E.getEditContents ie
+    cmdlineToks = words cmdline
+    cmd         = head cmdlineToks
+    args        = tail cmdlineToks
+    gameAnnounce = case args of
+      [n, gc, playerName] -> do
+        let mn = readMaybe n
+        liftIO $ atomically $ modifyTVar gsTV $ \ gs -> gs
+          & networkStatus                .~ Request GameAnnounce
+          & myName                       .~ playerName
+          -- TODO: ne pas utiliser gameSettings, mais passer directement gamecode et numberOfPlayers à (Request GameAnnounce ...)
+          & gameSettings.gameCode        .~ gc
+          & gameSettings.numberOfPlayers .~ fromMaybe 0 mn
+        when (isNothing mn) $ logText %= (<>["oops! Le nombre de joueurs '" <> n <> "' n'a pas pu être résolu à un entier!"])
+      _ -> return ()
+    requestJoinGame = case args of
+      [gc, playerName] -> do
+        liftIO $ atomically $ modifyTVar gsTV $ \ gs -> gs
+          & networkStatus                .~ Request JoinGame
+          & myName                       .~ playerName
+          -- TODO: ne pas utiliser gameSettings, mais passer directement gamecode à (Request GameAnnounce ...)
+          & gameSettings.gameCode        .~ gc
+      _ -> return ()
+    printGameState = do
+      gs <- liftIO $ readTVarIO gsTV
+      logText %= (<> lines (show gs))
+    exec
+      | cmd == "aide"                            = focusRing %= F.focusSetCurrent HelpBox
+      | cmd `elem` [ "ga",  "gameAnnounce"    ] = gameAnnounce
+      | cmd `elem` [ "rj",  "requestJoinGame" ] = requestJoinGame
+      | cmd `elem` [ "pgs", "printGameState"  ] = printGameState
+      | cmd `elem` [ "cl",  "clearLog"        ] = clearLog
+      | otherwise     = logText %= (<>["err.. impossible d'exécuter cette commande!"])
+  logText %= (<>[">>> " <> cmdline])
+  exec
+  clearEditorInputText
+  M.vScrollToEnd logViewportScroll
+
+appEvent :: BrickEvent AppFocus () -> EventM AppFocus NodeState ()
+appEvent ev = do
+  let
+    inputEvents (T.VtyEvent (V.EvKey V.KEsc []))               = M.halt
+    inputEvents (T.VtyEvent (V.EvKey V.KEnter []))             = executeCmd
+    inputEvents (T.VtyEvent (V.EvKey V.KPageUp []))            = M.vScrollPage logViewportScroll T.Up
+    inputEvents (T.VtyEvent (V.EvKey V.KPageDown []))          = M.vScrollPage logViewportScroll T.Down
+    inputEvents (T.VtyEvent (V.EvKey (V.KChar 'l') [V.MCtrl])) = clearLog
+    inputEvents (T.VtyEvent (V.EvKey (V.KChar '?') [] ))       = focusRing %= F.focusSetCurrent HelpBox
+    inputEvents ev'                                            = T.zoom inputEditor $ E.handleEditorEvent ev'
+
+    helpBoxEvents :: BrickEvent AppFocus () -> EventM AppFocus NodeState ()
+    helpBoxEvents (T.VtyEvent (V.EvKey V.KEsc []))         = focusRing %= F.focusSetCurrent Input
+    helpBoxEvents (T.VtyEvent (V.EvKey (V.KChar 'q') [] )) = focusRing %= F.focusSetCurrent Input
+    helpBoxEvents _                                        = return ()
+  r <- use focusRing
+  case F.focusGetCurrent r of
+    Just Input   -> inputEvents ev
+    Just HelpBox -> helpBoxEvents ev
+    _            -> return ()
+
+attrsMap :: AttrMap
+attrsMap = attrMap defAttr [ ]
+
+drawUI :: NodeState -> [Widget AppFocus]
+drawUI ns = helpBox <> [mainUI]
+  where
+    mainUI           = vBox [ B.border $ viewport Log T.Vertical $ vBox $ map str $ ns ^. logText
+                        , B.border $ str "node> " <+> vLimit 1 inputTextBox
+                        ]
+    inputTextBox     = F.withFocusRing (ns^.focusRing) (E.renderEditor (str . head)) (ns^.inputEditor)
+    cmdsHelpText     = B.borderWithLabel (str "COMMANDES") $ str $ unlines
+                       [ "aide"
+                       , "  Affiche l'aide de cet utilitaire."
+                       , ""
+                       , "ga {n} {code} {nomHôte}"
+                       , "gameAnnounce {n} {code} {nomHôte}"
+                       , "  Annonce une partie à {n} joueurs sur le réseau"
+                       , "  avec un code {code} et un nom de joueur de"
+                       , "  l'hôte {nomHôte}."
+                       , ""
+                       , "rj {code} {nomJoueur}"
+                       , "requestJoinGame {code} {nomJoueur}"
+                       , "  Demande d'accéder à la partie en tant que {nomJoueur}"
+                       , "  en utilisant le code {code}."
+                       , ""
+                       , "pgs"
+                       , "printGameState"
+                       , "  Affiche l'état actuel du jeu."
+                       , ""
+                       , "cl"
+                       , "clearLog"
+                       , "  Efface le contenu du journal."
+                       ]
+    keybindsHelpText = B.borderWithLabel (str "TOUCHES") $ str $ unlines
+                       [ "?:      Affiche l'aide de cet utilitaire."
+                       , "CTRL-l: Efface le contenu du journal."
+                       , "ESC, q: Quitter la fenêtre / le programme."
+                       ]
+    helpBox      = case F.focusGetCurrent (ns ^. focusRing) of
+                     Just HelpBox -> [ C.centerLayer $ hLimit 60 $ vBox [ C.hCenter cmdsHelpText
+                                                                        , C.hCenter keybindsHelpText
+                                                                        ]
+                                     ]
+                     _            -> []
+
+
+app :: M.App NodeState () AppFocus
+app = M.App { M.appDraw         = drawUI
+            , M.appChooseCursor = F.focusRingCursor (^.focusRing)
+            , M.appHandleEvent  = appEvent
+            , M.appStartEvent   = focusRing %= F.focusSetCurrent Input
+            , M.appAttrMap      = const attrsMap
+            }
+
+myForkIO :: IO () -> IO (MVar ())
+myForkIO io = do
+  mvar <- newEmptyMVar
+  void $ forkFinally io (\_ -> putMVar mvar ())
+  return mvar
+
+main :: IO ()
+main = do
+  gsTV <- newTVarIO defaultOnlineGameState
+  mv   <- myForkIO $ runReaderT (Network.loop def) gsTV
+  void $ M.defaultMain app $ NodeState { _focusRing   = F.focusRing $ enumFrom minBound
+                                       , _inputEditor = E.editor Input Nothing ""
+                                       , _logText     = []
+                                       , _gameStateTV = gsTV
+                                       }
+  atomically $ modifyTVar gsTV $ networkStatus .~ ShuttingDown
+  readMVar mv
+
+--  vim: set sts=2 ts=2 sw=2 tw=120 et :
+

--- a/src/tools/node/Main.hs
+++ b/src/tools/node/Main.hs
@@ -66,11 +66,11 @@ executeCmd = do
   ie   <- use inputEditor
   gsTV <- use gameStateTV
   let
-    cmdline     = head $ E.getEditContents ie
-    cmdlineToks = words cmdline
-    cmd         = head cmdlineToks
-    args        = tail cmdlineToks
-    gameAnnounce = case args of
+    cmdline      = head $ E.getEditContents ie
+    cmdlineToks  = words cmdline
+    cmd          = head cmdlineToks
+    args         = tail cmdlineToks
+    announceGame = case args of
       [n, gc, playerName] -> do
         let mn = readMaybe n
         liftIO $ atomically $ modifyTVar gsTV $ \ gs -> gs
@@ -94,7 +94,7 @@ executeCmd = do
       logText %= (<> lines (show gs))
     exec
       | cmd == "aide"                            = focusRing %= F.focusSetCurrent HelpBox
-      | cmd `elem` [ "ga",  "gameAnnounce"    ] = gameAnnounce
+      | cmd `elem` [ "ag",  "announceGame"    ] = announceGame
       | cmd `elem` [ "rj",  "requestJoinGame" ] = requestJoinGame
       | cmd `elem` [ "pgs", "printGameState"  ] = printGameState
       | cmd `elem` [ "cl",  "clearLog"        ] = clearLog
@@ -140,8 +140,8 @@ drawUI ns = helpBox <> [mainUI]
                        [ "aide"
                        , "  Affiche l'aide de cet utilitaire."
                        , ""
-                       , "ga {n} {code} {nomHôte}"
-                       , "gameAnnounce {n} {code} {nomHôte}"
+                       , "ag {n} {code} {nomHôte}"
+                       , "announceGame {n} {code} {nomHôte}"
                        , "  Annonce une partie à {n} joueurs sur le réseau"
                        , "  avec un code {code} et un nom de joueur de"
                        , "  l'hôte {nomHôte}."

--- a/src/tools/node/Main.hs
+++ b/src/tools/node/Main.hs
@@ -1,4 +1,13 @@
 
+{-|
+  Module      : Main
+  Description : Point d'entrée de l'outil habanga-node
+  Copyright   : (c) Simon Désaulniers, 2025
+  License     : GPL-3
+
+  Maintainer  : sim.desaulniers@gmail.com
+-}
+
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 

--- a/src/tools/node/Main.hs
+++ b/src/tools/node/Main.hs
@@ -20,7 +20,6 @@ import Text.Read
 
 import Control.Monad
 import Control.Monad.Reader
-import Control.Monad.Trans
 import Control.Lens
 import Control.Concurrent
 import Control.Concurrent.STM

--- a/src/tools/node/Main.hs
+++ b/src/tools/node/Main.hs
@@ -99,10 +99,11 @@ executeCmd = do
       | cmd `elem` [ "pgs", "printGameState"  ] = printGameState
       | cmd `elem` [ "cl",  "clearLog"        ] = clearLog
       | otherwise     = logText %= (<>["err.. impossible d'exécuter cette commande!"])
-  logText %= (<>[">>> " <> cmdline])
-  exec
-  clearEditorInputText
-  M.vScrollToEnd logViewportScroll
+  unless (null cmdline) $ do
+    logText %= (<>[">>> " <> cmdline])
+    exec
+    M.vScrollToEnd logViewportScroll
+    clearEditorInputText
 
 appEvent :: BrickEvent AppFocus () -> EventM AppFocus NodeState ()
 appEvent ev = do

--- a/src/tools/node/Main.hs
+++ b/src/tools/node/Main.hs
@@ -132,7 +132,9 @@ executeCmd = do
             let (c, b) = fromEitherCard ec
             (mNumberOfCardsDrawn, gs') <- flip runStateT gs $ runMaybeT $ processPlayerTurnAction c b
             case mNumberOfCardsDrawn of
-              Just _  -> do
+              Just nCardsToDraw  -> do
+                when (nCardsToDraw > 0) $
+                  logText %= (<> ["Vous pigez " <> show nCardsToDraw <> " carte(s)!"])
                 gameState .= gs'
                 liftIO $ atomically $ modifyTVar (gs^?!networkState) changeNetState
               Nothing -> logText %= (<>["err.. Impossible de jouer cette carte!"])

--- a/src/tools/node/Main.hs
+++ b/src/tools/node/Main.hs
@@ -98,6 +98,7 @@ executeCmd = do
       | cmd `elem` [ "rj",  "requestJoinGame" ] = requestJoinGame
       | cmd `elem` [ "pgs", "printGameState"  ] = printGameState
       | cmd `elem` [ "cl",  "clearLog"        ] = clearLog
+      | cmd `elem` [ "q",   "quit"            ] = M.halt
       | otherwise     = logText %= (<>["err.. impossible d'exécuter cette commande!"])
   unless (null cmdline) $ do
     logText %= (<>[">>> " <> cmdline])
@@ -108,7 +109,6 @@ executeCmd = do
 appEvent :: BrickEvent AppFocus () -> EventM AppFocus NodeState ()
 appEvent ev = do
   let
-    inputEvents (T.VtyEvent (V.EvKey V.KEsc []))               = M.halt
     inputEvents (T.VtyEvent (V.EvKey V.KEnter []))             = executeCmd
     inputEvents (T.VtyEvent (V.EvKey V.KPageUp []))            = M.vScrollPage logViewportScroll T.Up
     inputEvents (T.VtyEvent (V.EvKey V.KPageDown []))          = M.vScrollPage logViewportScroll T.Down
@@ -158,11 +158,15 @@ drawUI ns = helpBox <> [mainUI]
                        , "cl"
                        , "clearLog"
                        , "  Efface le contenu du journal."
+                       , ""
+                       , "q"
+                       , "quit"
+                       , "  Quitter le programme."
                        ]
     keybindsHelpText = B.borderWithLabel (str "TOUCHES") $ str $ unlines
                        [ "?:      Affiche l'aide de cet utilitaire."
                        , "CTRL-l: Efface le contenu du journal."
-                       , "ESC, q: Quitter la fenêtre / le programme."
+                       , "ESC, q: Quitter la fenêtre."
                        ]
     helpBox      = case F.focusGetCurrent (ns ^. focusRing) of
                      Just HelpBox -> [ C.centerLayer $ hLimit 60 $ vBox [ C.hCenter cmdsHelpText

--- a/src/tools/node/Main.hs
+++ b/src/tools/node/Main.hs
@@ -129,8 +129,7 @@ executeCmd = do
             PlayTurn <$> mCard
         case mPlayerTurn of
           Just (PlayTurn ec) -> do
-            let (c, b) = fromEitherCard ec
-            (mNumberOfCardsDrawn, gs') <- flip runStateT gs $ runMaybeT $ processPlayerTurnAction c b
+            (mNumberOfCardsDrawn, gs') <- flip runStateT gs $ runMaybeT $ processPlayerTurnAction ec
             case mNumberOfCardsDrawn of
               Just nCardsToDraw  -> do
                 when (nCardsToDraw > 0) $
@@ -144,10 +143,9 @@ executeCmd = do
       let
         consecutivePlayerTurns' = consecutivePlayerTurns netState (netState ^. gameTurns)
       case consecutivePlayerTurns' of
-        ((n, turn):_) -> do
+        ((n, ec):_) -> do
           gs' <- flip execStateT gs $ do
-            let (c, b) = fromEitherCard turn
-            runMaybeT $ processPlayerTurnAction c b
+            runMaybeT $ processPlayerTurnAction ec
           gameState .= gs'
           liftIO $ atomically $ modifyTVar (gs^?!networkState) $ gameTurns %~ Map.delete n
         _ -> logText %= (<>["err.. Aucun tour à traiter!"])

--- a/src/tools/node/Node.hs
+++ b/src/tools/node/Node.hs
@@ -1,0 +1,15 @@
+{-|
+  Module      : Node
+  Description : Fonctions réseau d'un nœud Habanga
+  Copyright   : (c) Simon Désaulniers, 2025
+  License     : GPL-3
+
+  Maintainer  : sim.desaulniers@gmail.com
+-}
+
+module Node where
+
+
+
+--  vim: set sts=2 ts=2 sw=2 tw=120 et :
+

--- a/src/tui/GameView.hs
+++ b/src/tui/GameView.hs
@@ -95,10 +95,10 @@ playCard rb = do
 
   let
     cardsDrawnLog = [">> " <> "pige " <> show (cardsDrawn^?!_Just) <> " carte(s)!" | ((>0) <$> cardsDrawn) == Just True]
-    playerLog     = List.intercalate "\n" $ [ "Joueur " <> currentPlayer^.name <> ": "
-                                            , ">> "     <> "a joué le " <> show (card^.value) <> " " <> cardColorStr <> "."
-                                            ] <> cardsDrawnLog
-                                              <> ["\n"]
+    playerLog     = unlines $ [ "Joueur " <> currentPlayer^.name <> ": "
+                              , ">> "     <> "a joué le " <> show (card^.value) <> " " <> cardColorStr <> "."
+                              ] <> cardsDrawnLog
+                                <> ["\n"]
   gameViewState . gameLog %= (:) playerLog
 
   theWinner <- Game.winner

--- a/src/tui/MainMenu.hs
+++ b/src/tui/MainMenu.hs
@@ -78,7 +78,8 @@ goBackOrQuit = use (mainMenuState.submenu) >>= \ case
 
 startGame :: [String] -> T.EventM AppFocus ProgramState ()
 startGame playerList = do
-  gameState <~ liftIO (initialize playerList)
+  -- FIXME: il faudra utiliser initialize avec un générateur basé sur le code de la partie.
+  gameState <~ liftIO (initializeIO playerList)
   currentFocus %= focusSetCurrent (Game Nothing)
 
 event :: T.BrickEvent AppFocus () -> T.EventM AppFocus ProgramState ()

--- a/src/tui/MainMenu.hs
+++ b/src/tui/MainMenu.hs
@@ -118,8 +118,9 @@ mkGameInitializationForm :: GameInitializationInfo -> Form GameInitializationInf
 mkGameInitializationForm =
     let label s w    = padLeft (Pad 1) $ padBottom (Pad 1) $ vLimit 2 (hLimit 20 $ str s <+> fill ' ') <+> w
         mMaxNumNames = Just _HABANGA_MAX_PLAYER_COUNT_
+        focusedItem    = MainMenu (GameInitializationForm GameInitializationFormPlayerNamesField)
     in newForm [ label "Nom des joueurs" @@= B.border
-                                         @@= editTextField playerNamesField (MainMenu (GameInitializationForm GameInitializationFormPlayerNamesField)) mMaxNumNames
+                                         @@= editTextField playerNamesField focusedItem mMaxNumNames
                ]
 
 gameInitializationSubMenu :: ProgramState -> [Widget AppFocus]


### PR DESCRIPTION
* Network: opérations réseau pour une partie en ligne
  * annonce d'une partie
  * joindre une partie
  * jouer son tour et le partager avec les autres joueurs
  * réception des tours des autres joueurs
  Le modèle de protocole admet un hôte et des invités. L'hôte est celui qui
  génère le code de la partie et l'anonce sur le réseau.
* NetworkState: état de la couche réseau. Celle-ci est gérée par
  le module Network et en partie à la demande de la couche appelante par
  le passage de requêtes via la configuration du "statut réseau"
  (NetworkStatus). Ce statut sert donc à communiquer autant la phase réseau, une
  erreur rencontrée ou une requête de l'appelant à la couche réseau.
* core/Game:
  * réinitialisation du jeu à partir d'un état existant
  * brasser les cartes de manière déterministe
  * usage de Either plutôt que RangeBoudary
* core/GameState:
  * defaultOnlineGameState, construction par défaut
    d'un GameState par OnlineGameState (TVar NetworkState).
  * considérer OnlineGameState dans l'instance Show.
* tui/GameView: unlines plutôt que intercalate "\n"
* opendht-hs: nouvelle dépendance comme sous-module git
* github: image docker incluant la dépendance de compilation opendht-c