### PR TITLE
habanga-tui: mode multijoueur

### DIFF
--- a/habanga.cabal
+++ b/habanga.cabal
@@ -64,6 +64,7 @@ library habanga-core
     import:             common-base,
                         common-lang
     exposed-modules:    Game
+                        OnlineGame
                         Cards
                         GameState
                         NetworkState

--- a/habanga.cabal
+++ b/habanga.cabal
@@ -50,7 +50,7 @@ common common-base
                         containers   ^>= 0.6.7,
                         data-default ^>= 0.8.0,
                         stm,
-                        extra
+                        extra,
 common common-exe
     ghc-options:        -threaded
 
@@ -98,6 +98,8 @@ executable habanga-tui
                         Widgets
     build-depends:      habanga-core,
                         text       ^>= 2.0.2,
-                        file-embed ^>= 0.0.16
+                        file-embed ^>= 0.0.16,
+                        opendht-hs,
+                        directory
     hs-source-dirs:     src/tui
 

--- a/habanga.cabal
+++ b/habanga.cabal
@@ -96,6 +96,7 @@ executable habanga-tui
                         MainMenu,
                         GameView,
                         Widgets
+                        BrickNetworkBridge
     build-depends:      habanga-core,
                         text       ^>= 2.0.2,
                         file-embed ^>= 0.0.16,

--- a/habanga.cabal
+++ b/habanga.cabal
@@ -49,8 +49,8 @@ common common-base
                         mtl          ^>= 2.2.2,
                         containers   ^>= 0.6.7,
                         data-default ^>= 0.8.0,
-                        stm,
-                        extra,
+                        stm          ^>= 2.5.1,
+                        extra        ^>= 1.8,
 common common-exe
     ghc-options:        -threaded
 
@@ -70,10 +70,10 @@ library habanga-core
                         NetworkState
                         Network
                         Random
-    build-depends:      random >= 1.2.1 && < 1.3,
-                        opendht-hs,
-                        serialise,
-                        bytestring
+    build-depends:      random     ^>= 1.2.1,
+                        opendht-hs ^>= 0.1.0,
+                        serialise  ^>= 0.2.6,
+                        bytestring ^>= 0.11.5,
     hs-source-dirs:     src/core
 
 executable habanga-node
@@ -102,6 +102,6 @@ executable habanga-tui
                         text       ^>= 2.0.2,
                         file-embed ^>= 0.0.16,
                         opendht-hs,
-                        directory
+                        directory  ^>= 1.3.7,
     hs-source-dirs:     src/tui
 

--- a/src/core/Game.hs
+++ b/src/core/Game.hs
@@ -13,7 +13,6 @@
 
 module Game ( initializeIO
             , initialize
-            , reInitialize
             , winner
             , processPlayerTurnAction
             , RangeBoundary (..)
@@ -66,12 +65,6 @@ initialize playerNames gen = do
   flip execStateT initialGameState $ replicateM_ (length playerNames) $ do
     drawCards 8
     endPlayerTurn
-
-reInitialize :: RandomGen gen => [String] -> GameState -> gen -> IO GameState
-reInitialize playerNames gs gen = initialize playerNames gen >>= \ gs' -> return $ gs
-  & cardsOnTable .~ gs' ^. cardsOnTable
-  & deck         .~ gs' ^. deck
-  & players      .~ gs' ^. players
 
 {-| Exécute toute les actions nécessaires lors de la terminaison du tour
    du joueur.

--- a/src/core/GameState.hs
+++ b/src/core/GameState.hs
@@ -14,6 +14,7 @@
 module GameState where
 
 import Data.Default
+import qualified Data.List as List
 
 import Control.Lens
 
@@ -85,6 +86,9 @@ instance Show GameState where
 gameStateLens :: (GameStated s, Functor f)
               => (GameState -> f GameState) -> s -> f s --
 gameStateLens g s = fmap (setGameState s) (g $ getGameState s)
+
+playerRank :: String -> GameState -> Maybe Int
+playerRank pname gs = List.elemIndex pname $ map (view name) (gs^.players)
 
 --  vim: set sts=2 ts=2 sw=2 tw=120 et :
 

--- a/src/core/GameState.hs
+++ b/src/core/GameState.hs
@@ -16,11 +16,8 @@ module GameState where
 import Data.Default
 
 import Control.Lens
-import Control.Monad.IO.Class
-import Control.Concurrent.STM
 
 import Cards
-import NetworkState
 
 data CardsOnTable = CardsOnTable { _red    :: (Card, Card)
                                  , _yellow :: (Card, Card)
@@ -45,17 +42,9 @@ data GameState = GameState { _cardsOnTable :: CardsOnTable
                            , _deck         :: [Card]
                            , _players      :: [PlayerState]
                            }
-               | OnlineGameState { _cardsOnTable :: CardsOnTable
-                                 , _deck         :: [Card]
-                                 , _players      :: [PlayerState]
-                                 , _networkState :: TVar NetworkState
-                                 }
 makeLenses ''GameState
 
 class GameStated a where
-  -- TODO: de façon à utiliser TVar
-  -- getGameState :: a -> IO GameState
-  -- setGameState :: a -> GameState -> IO a
   getGameState :: a -> GameState
   setGameState :: a -> GameState -> a
 
@@ -88,14 +77,6 @@ instance Show GameState where
             ++ unlines [ "Cards on table:"
                       , unlines $ map ("    "++) (lines (show $ gs^.cardsOnTable))
                       ]
-
-defaultOnlineGameState :: MonadIO m => m GameState
-defaultOnlineGameState = liftIO (newTVarIO def) >>= \ nsTV ->
-  return OnlineGameState { _cardsOnTable = def ^. cardsOnTable
-                         , _deck         = def ^. deck
-                         , _players      = def ^. players
-                         , _networkState = nsTV
-                         }
 
 {-| Lentille (Lens' s GameState)
 

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -132,10 +132,10 @@ newNetworkStatusSafe nStatus ns = let currentNetworkStatus = ns ^. status in cas
   _                 -> nStatus
 
 atomicallyHandleStateUpdate :: NetworkStateChannelData -> STM a -> IO a
-atomicallyHandleStateUpdate (NetworkStateChannelData nsTV chan) stateAction = do
-  a  <- atomically stateAction
-  ns <- readTVarIO nsTV
-  atomically $ writeTChan chan (NetworkChannelUpdate ns)
+atomicallyHandleStateUpdate (NetworkStateChannelData nsTV chan) stateAction = atomically $ do
+  a  <- stateAction
+  ns <- readTVar nsTV
+  writeTChan chan (NetworkChannelUpdate ns)
   return a
 
 

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -178,11 +178,11 @@ gameOnGoingCb ncdata@(NetworkStateChannelData nsTV _) (StoredValue d _ _ _ utype
       | sId == ns ^. myID = (True, ns)
       | otherwise         = (True, ns')
       where
-        ns'                    = ns & gameTurns     .~ gameTurns'
-                                    & status .~ newNetworkStatusSafe networkStatus' ns
-        gameTurns'             = Map.insert tn card (ns^.gameTurns)
-        lastTurnNumber         = fromIntegral $ fst $ last $ consecutivePlayerTurns ns gameTurns'
-        isOurTurn              = lastTurnNumber `mod` (ns ^?! gameSettings . numberOfPlayers) == ns ^?! myPlayerRank
+        ns'            = ns & gameTurns .~ gameTurns'
+                            & status    .~ newNetworkStatusSafe networkStatus' ns
+        gameTurns'     = Map.insert tn card (ns^.gameTurns)
+        lastTurnNumber = fromIntegral $ fst $ last $ consecutivePlayerTurns ns gameTurns'
+        isOurTurn      = lastTurnNumber `mod` (ns ^?! gameSettings . numberOfPlayers) == ns ^?! myPlayerRank
         networkStatus'
           | isOurTurn = GameOnGoing AwaitingPlayerTurn
           | otherwise = ns ^. status

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -18,6 +18,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Network ( loop
+               , forkFinallyWithMvar
                ) where
 
 import GHC.Generics
@@ -55,6 +56,12 @@ import qualified OpenDHT.DhtRunner as DhtRunner
 
 import Cards
 import NetworkState
+
+forkFinallyWithMvar :: IO () -> IO (MVar ())
+forkFinallyWithMvar io = do
+  mvar <- newEmptyMVar
+  void $ forkFinally io (\_ -> putMVar mvar ())
+  return mvar
 
 -- Le temps de pause de la boucle en microsecondes
 _MAIN_LOOP_THREAD_SLEEP_TIME_ :: Int

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -148,7 +148,7 @@ playMyTurn card ncdata@(NetworkStateChannelData nsTV _) = liftIO (readTVarIO nsT
   gcHash <- liftIO $ unDht $ infoHashFromString $ ns ^. gameSettings . gameCode
   let
     packet          = HabangaPacket { _senderID = ns ^. myID
-                                    , _content  = PlayerTurn card (ns ^?! turnNumber + 1)
+                                    , _content  = PlayerTurn card (ns ^?! turnNumber)
                                     }
     playerTurnValue = InputValue { _valueData     = BS.toStrict $ serialise packet
                                  , _valueUserType = _PLAYER_TURN_UTYPE_

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -357,7 +357,11 @@ handleRequest ncdata@(NetworkStateChannelData nsTV reqChan _) = liftIO (atomical
         & myPlayerRank  .~ myRank
         & turnNumber    .~ 0
       void $ DhtRunner.listen gcHash (gameOnGoingCb ncdata) shutdownCb
-    handleReq (PlayTurn tn card) = playMyTurn tn card ncdata
+    handleReq (PlayTurn card) = do
+      ns <- liftIO $ readTVarIO nsTV
+      liftIO $ atomically $ modifyTVar nsTV $ turnNumber +~ 1
+      playMyTurn (ns ^. turnNumber) card ncdata
+    handleReq (UpdateTurnNumber tn) = liftIO $ atomicallyHandleStateUpdate ncdata $ modifyTVar nsTV $ turnNumber .~ tn
     handleReq ResetNetwork = do
       ns <- liftIO $ readTVarIO nsTV
       clearPendingDhtOps ns

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -182,8 +182,8 @@ gameOnGoingCb ncdata@(NetworkStateChannelData nsTV _) (StoredValue d _ _ _ utype
                             & status    .~ newNetworkStatusSafe networkStatus' ns
         gameTurns'     = Map.insert tn card (ns^.gameTurns)
         lastTurnNumber = fromIntegral $ fst $ last $ consecutivePlayerTurns ns gameTurns'
-        n              = ns ^?! gameSettings . numberOfPlayers
-        isOurTurn      = lastTurnNumber `mod` n == (ns ^?! myPlayerRank - 1) `mod` n
+        n              = ns ^. gameSettings . numberOfPlayers
+        isOurTurn      = lastTurnNumber `mod` n == (ns ^. myPlayerRank - 1) `mod` n
         networkStatus'
           | isOurTurn = GameOnGoing AwaitingPlayerTurn
           | otherwise = ns ^. status

--- a/src/core/Network.hs
+++ b/src/core/Network.hs
@@ -19,6 +19,7 @@
 
 module Network ( loop
                , forkFinallyWithMvar
+               , requestNetwork
                ) where
 
 import GHC.Generics
@@ -108,6 +109,9 @@ _GAME_SETUP_UTYPE_ = show $ toConstr $ GameSetup mempty
 
 _PLAYER_TURN_UTYPE_ :: String
 _PLAYER_TURN_UTYPE_ = show $ toConstr $ PlayerTurn (Left def) 0
+
+requestNetwork :: MonadIO m => TVar NetworkState -> NetworkRequest -> m ()
+requestNetwork nsTV r = liftIO $ atomically $ modifyTVar nsTV $ status .~ Request r
 
 -- TODO:
 shutdownCb :: ShutdownCallback

--- a/src/core/NetworkState.hs
+++ b/src/core/NetworkState.hs
@@ -28,7 +28,8 @@ data OnlineGameStatus = AwaitingPlayerTurn
 data NetworkRequest = GameAnnounce OnlineGameSettings String
                     | JoinGame GameCode String
                     | GameStart Int
-                    | PlayTurn Word16 (Either Card Card)
+                    | PlayTurn (Either Card Card)
+                    | UpdateTurnNumber Word16
                     | ResetNetwork
                     deriving Show
 data NetworkEvent = Connection

--- a/src/core/NetworkState.hs
+++ b/src/core/NetworkState.hs
@@ -115,9 +115,10 @@ splitAtMissingTurn ns gameTurns' = (consecutivePlayerTurns', rest)
     consecutivePlayerTurns' = consecutivePlayerTurns ns gameTurns'
 
 consecutivePlayerTurns :: NetworkState -> Map Word16 (Either Card Card) -> [GameTurn]
-consecutivePlayerTurns ns gameTurns' = map fst $ takeWhile turnIsSubsequent $ zip (Map.toList gameTurns') [ns^.turnNumber..]
+consecutivePlayerTurns ns gameTurns' = map fst $ takeWhile turnIsSubsequent $ zip gameTurnsFromTurnNumber [ns^.turnNumber..]
   where
-    turnIsSubsequent ((t',_), t) = t' == t + 1
+    turnIsSubsequent ((t',_), t) = t' == t
+    gameTurnsFromTurnNumber      = dropWhile ((< ns ^. turnNumber) . fst) $ Map.toList gameTurns'
 
 --  vim: set sts=2 ts=2 sw=2 tw=120 et :
 

--- a/src/core/NetworkState.hs
+++ b/src/core/NetworkState.hs
@@ -8,7 +8,6 @@ import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Default
 
-import Control.Concurrent.STM.TVar
 import Control.Concurrent.STM.TChan
 import Control.Lens
 

--- a/src/core/NetworkState.hs
+++ b/src/core/NetworkState.hs
@@ -28,7 +28,7 @@ data OnlineGameStatus = AwaitingPlayerTurn
 data NetworkRequest = GameAnnounce OnlineGameSettings String
                     | JoinGame GameCode String
                     | GameStart Int
-                    | PlayTurn (Either Card Card)
+                    | PlayTurn Word16 (Either Card Card)
                     | ResetNetwork
                     deriving Show
 data NetworkEvent = Connection

--- a/src/core/NetworkState.hs
+++ b/src/core/NetworkState.hs
@@ -53,6 +53,8 @@ data OnlineGameSettings = OnlineGameSettings { _gameCode        :: GameCode
                                              deriving Show
 makeLenses ''OnlineGameSettings
 
+type GameTurn = (Word16, Either Card Card)
+
 data NetworkState = NetworkState { _gameTurns         :: Map Word16 (Either Card Card)
                                  , _playersIdentities :: Map OnlinePlayerID OnlinePlayerName
                                  , _status            :: NetworkStatus
@@ -105,13 +107,13 @@ _GAME_CODE_LENGTH_ = 6
 _MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ :: Int
 _MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ = 6
 
-splitAtMissingTurn :: NetworkState -> Map Word16 (Either Card Card) -> ([(Word16, Either Card Card)], [(Word16, Either Card Card)])
+splitAtMissingTurn :: NetworkState -> Map Word16 (Either Card Card) -> ([GameTurn], [GameTurn])
 splitAtMissingTurn ns gameTurns' = (consecutivePlayerTurns', rest)
   where
     rest = map snd $ dropWhile (uncurry (==)) $ zip (Map.toList gameTurns') consecutivePlayerTurns'
     consecutivePlayerTurns' = consecutivePlayerTurns ns gameTurns'
 
-consecutivePlayerTurns :: NetworkState -> Map Word16 (Either Card Card) -> [(Word16, Either Card Card)]
+consecutivePlayerTurns :: NetworkState -> Map Word16 (Either Card Card) -> [GameTurn]
 consecutivePlayerTurns ns gameTurns' = map fst $ takeWhile turnIsSubsequent $ zip (Map.toList gameTurns') [ns^.turnNumber..]
   where
     turnIsSubsequent ((t',_), t) = t' == t + 1

--- a/src/core/NetworkState.hs
+++ b/src/core/NetworkState.hs
@@ -14,9 +14,8 @@ import Control.Lens
 
 import Cards
 
-type GameCode = String
-
-type OnlinePlayerID = String
+type GameCode         = String
+type OnlinePlayerID   = String
 type OnlinePlayerName = String
 
 data NetworkFailureType = GameAnnouncementFailure String
@@ -44,6 +43,7 @@ data NetworkStatus = AwaitingRequest
                    | GameOnGoing OnlineGameStatus
                    | GameEnded
                    | ShuttingDown
+                   | Offline
                    | NetworkFailure NetworkFailureType
                    deriving Show
 
@@ -68,15 +68,15 @@ data NetworkState = NetworkState { _gameTurns         :: Map Word16 (Either Card
 makeLenses ''NetworkState
 
 instance Default NetworkState where
-  def = NetworkState { _gameTurns         =  Map.empty
-                     , _playersIdentities =  mempty
-                     , _status            =  AwaitingRequest
-                     , _gameSettings      =  OnlineGameSettings [] 0
-                     , _gameHostID        =  ""
-                     , _turnNumber        =  0
-                     , _myID              =  ""
-                     , _myName            =  ""
-                     , _myPlayerRank      =  0
+  def = NetworkState { _gameTurns         = Map.empty
+                     , _playersIdentities = mempty
+                     , _status            = Offline
+                     , _gameSettings      = OnlineGameSettings [] 0
+                     , _gameHostID        = ""
+                     , _turnNumber        = 0
+                     , _myID              = ""
+                     , _myName            = ""
+                     , _myPlayerRank      = 0
                      }
 
 instance Show NetworkState where

--- a/src/core/NetworkState.hs
+++ b/src/core/NetworkState.hs
@@ -31,6 +31,7 @@ data NetworkRequest = GameAnnounce OnlineGameSettings String
                     | PlayTurn (Either Card Card)
                     | UpdateTurnNumber Word16
                     | ResetNetwork
+                    | Shutdown
                     deriving Show
 data NetworkEvent = Connection
                   | GameStarted
@@ -98,11 +99,10 @@ instance Show NetworkState where
 
 newtype NetworkChannelUpdate = NetworkChannelUpdate NetworkState
 
-data NetworkStateChannelData = NetworkStateChannelData { _networkState   :: TVar NetworkState
-                                                       , _requestChannel :: TChan NetworkRequest
-                                                       , _updateChannel  :: TChan NetworkChannelUpdate
-                                                       }
-makeLenses ''NetworkStateChannelData
+data NetworkTwoWayChannel = NetworkTwoWayChannel { _requestChannel :: TChan NetworkRequest
+                                                 , _updateChannel  :: TChan NetworkChannelUpdate
+                                                 }
+makeLenses ''NetworkTwoWayChannel
 
 _GAME_CODE_LENGTH_ :: Int
 _GAME_CODE_LENGTH_ = 6

--- a/src/core/NetworkState.hs
+++ b/src/core/NetworkState.hs
@@ -8,6 +8,8 @@ import Data.Map (Map)
 import qualified Data.Map as Map
 import Data.Default
 
+import Control.Concurrent.STM.TVar
+import Control.Concurrent.STM.TChan
 import Control.Lens
 
 import Cards
@@ -89,6 +91,13 @@ instance Show NetworkState where
                     , "MyName:       " <> ns ^. myName
                     , "MyPlayerRank: " <> show (ns ^. myPlayerRank)
                     ]
+
+newtype NetworkChannelUpdate = NetworkChannelUpdate NetworkState
+
+data NetworkStateChannelData = NetworkStateChannelData { _networkState  :: TVar NetworkState
+                                                       , _updateChannel :: TChan NetworkChannelUpdate
+                                                       }
+makeLenses ''NetworkStateChannelData
 
 _MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ :: Int
 _MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ = 6

--- a/src/core/NetworkState.hs
+++ b/src/core/NetworkState.hs
@@ -92,6 +92,7 @@ instance Show NetworkState where
                     , "MyID:         " <> ns ^. myID
                     , "MyName:       " <> ns ^. myName
                     , "MyPlayerRank: " <> show (ns ^. myPlayerRank)
+                    , "TurnNumber:   " <> show (ns ^. turnNumber)
                     ]
 
 newtype NetworkChannelUpdate = NetworkChannelUpdate NetworkState

--- a/src/core/NetworkState.hs
+++ b/src/core/NetworkState.hs
@@ -36,7 +36,7 @@ data NetworkEvent = Connection
                   deriving Show
 data NetworkStatus = AwaitingRequest
                    | AwaitingEvent NetworkEvent
-                   | Request NetworkRequest
+                   | TreatingRequest
                    | SharingGameSetup
                    | SetupPhaseDone
                    | GameReadyForInitialization
@@ -97,8 +97,9 @@ instance Show NetworkState where
 
 newtype NetworkChannelUpdate = NetworkChannelUpdate NetworkState
 
-data NetworkStateChannelData = NetworkStateChannelData { _networkState  :: TVar NetworkState
-                                                       , _updateChannel :: TChan NetworkChannelUpdate
+data NetworkStateChannelData = NetworkStateChannelData { _networkState   :: TVar NetworkState
+                                                       , _requestChannel :: TChan NetworkRequest
+                                                       , _updateChannel  :: TChan NetworkChannelUpdate
                                                        }
 makeLenses ''NetworkStateChannelData
 

--- a/src/core/NetworkState.hs
+++ b/src/core/NetworkState.hs
@@ -99,6 +99,9 @@ data NetworkStateChannelData = NetworkStateChannelData { _networkState  :: TVar 
                                                        }
 makeLenses ''NetworkStateChannelData
 
+_GAME_CODE_LENGTH_ :: Int
+_GAME_CODE_LENGTH_ = 6
+
 _MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ :: Int
 _MAX_PLAYER_ID_SIZE_TO_CONSIDER_UNIQUE_ = 6
 

--- a/src/core/OnlineGame.hs
+++ b/src/core/OnlineGame.hs
@@ -6,10 +6,16 @@ import qualified Data.Map as Map
 
 import Numeric
 
+import Control.Monad.IO.Class
+import Control.Concurrent.STM
 import Control.Lens
 
 import System.Random
 
+import OpenDHT.Types
+import OpenDHT.InfoHash
+
+import qualified Network
 import NetworkState
 import Random
 
@@ -20,6 +26,18 @@ shuffledPlayerNames :: NetworkState -> StdGen -> [String]
 shuffledPlayerNames ns = deterministiclyShuffle sortedPlayerNames
   where
     sortedPlayerNames = List.sort $ Map.elems $ ns ^. playersIdentities
+
+createGame :: MonadIO m => TVar NetworkState -> String -> Int -> m ()
+createGame nsTV playerName numberOfPlayers' = do
+  rHash <- liftIO $ unDht randomInfoHash
+  let
+    gc              = take _GAME_CODE_LENGTH_ $ show rHash
+    playerNameStr   = playerName
+    theGameSettings = OnlineGameSettings gc numberOfPlayers'
+  Network.requestNetwork nsTV $ GameAnnounce theGameSettings playerNameStr
+
+joinGame :: MonadIO m => TVar NetworkState -> String -> String -> m ()
+joinGame nsTV playerName gc = Network.requestNetwork nsTV $ JoinGame gc playerName
 
 --  vim: set sts=2 ts=2 sw=2 tw=120 et :
 

--- a/src/core/OnlineGame.hs
+++ b/src/core/OnlineGame.hs
@@ -58,7 +58,7 @@ myCurrentPosInPlayerList ns = (myRank + tn) `mod` n
   where
     myRank = ns ^. myPlayerRank
     tn     = fromIntegral $ ns ^. turnNumber
-    n      = ns ^?! gameSettings . numberOfPlayers
+    n      = ns ^. gameSettings . numberOfPlayers
 
 isMyTurn :: NetworkState -> Bool
 isMyTurn ns = myCurrentPosInPlayerList ns == 0

--- a/src/core/OnlineGame.hs
+++ b/src/core/OnlineGame.hs
@@ -56,9 +56,8 @@ startGame nsTV = liftIO (readTVarIO nsTV) >>= \ ns -> do
 consumeConsecutivePlayerTurns :: NetworkState -> ([GameTurn], NetworkState)
 consumeConsecutivePlayerTurns ns = (turnsToConsume, ns')
   where
-    (turnsToConsume, rest) = splitAtMissingTurn ns (ns ^. gameTurns)
-    ns'                    = ns & gameTurns  .~ Map.fromList rest
-                                & turnNumber +~ fromIntegral (length turnsToConsume)
+    turnsToConsume = consecutivePlayerTurns ns (ns ^. gameTurns)
+    ns'            = ns & turnNumber +~ fromIntegral (length turnsToConsume)
 
 --  vim: set sts=2 ts=2 sw=2 tw=120 et :
 

--- a/src/core/OnlineGame.hs
+++ b/src/core/OnlineGame.hs
@@ -53,6 +53,16 @@ startGame nsTV = liftIO (readTVarIO nsTV) >>= \ ns -> do
   Network.requestNetwork nsTV $ GameStart myRank
   return gs
 
+myCurrentPosInPlayerList :: NetworkState -> Int
+myCurrentPosInPlayerList ns = (myRank + tn) `mod` n
+  where
+    myRank = ns ^. myPlayerRank
+    tn     = fromIntegral $ ns ^. turnNumber
+    n      = ns ^?! gameSettings . numberOfPlayers
+
+isMyTurn :: NetworkState -> Bool
+isMyTurn ns = myCurrentPosInPlayerList ns == 0
+
 consumeConsecutivePlayerTurns :: NetworkState -> ([GameTurn], NetworkState)
 consumeConsecutivePlayerTurns ns = (turnsToConsume, ns')
   where

--- a/src/core/OnlineGame.hs
+++ b/src/core/OnlineGame.hs
@@ -1,0 +1,25 @@
+
+module OnlineGame where
+
+import qualified Data.List as List
+import qualified Data.Map as Map
+
+import Numeric
+
+import Control.Lens
+
+import System.Random
+
+import NetworkState
+import Random
+
+randomGeneratorFromNetworkState :: NetworkState -> StdGen
+randomGeneratorFromNetworkState ns = mkStdGen (fst $ head $ readHex $ ns ^. gameSettings . gameCode)
+
+shuffledPlayerNames :: NetworkState -> StdGen -> [String]
+shuffledPlayerNames ns = deterministiclyShuffle sortedPlayerNames
+  where
+    sortedPlayerNames = List.sort $ Map.elems $ ns ^. playersIdentities
+
+--  vim: set sts=2 ts=2 sw=2 tw=120 et :
+

--- a/src/core/OnlineGame.hs
+++ b/src/core/OnlineGame.hs
@@ -53,5 +53,12 @@ startGame nsTV = liftIO (readTVarIO nsTV) >>= \ ns -> do
   Network.requestNetwork nsTV $ GameStart myRank
   return gs
 
+consumeConsecutivePlayerTurns :: NetworkState -> ([GameTurn], NetworkState)
+consumeConsecutivePlayerTurns ns = (turnsToConsume, ns')
+  where
+    (turnsToConsume, rest) = splitAtMissingTurn ns (ns ^. gameTurns)
+    ns'                    = ns & gameTurns  .~ Map.fromList rest
+                                & turnNumber +~ fromIntegral (length turnsToConsume)
+
 --  vim: set sts=2 ts=2 sw=2 tw=120 et :
 

--- a/src/core/OnlineGame.hs
+++ b/src/core/OnlineGame.hs
@@ -54,7 +54,7 @@ startGame nsTV = liftIO (readTVarIO nsTV) >>= \ ns -> do
   return gs
 
 myCurrentPosInPlayerList :: NetworkState -> Int
-myCurrentPosInPlayerList ns = (myRank + tn) `mod` n
+myCurrentPosInPlayerList ns = (myRank - tn) `mod` n
   where
     myRank = ns ^. myPlayerRank
     tn     = fromIntegral $ ns ^. turnNumber

--- a/src/tools/node/Main.hs
+++ b/src/tools/node/Main.hs
@@ -103,7 +103,7 @@ executeCmd = do
       let
         shuffPNames = OnlineGame.shuffledPlayerNames netState gen
         gen         = OnlineGame.randomGeneratorFromNetworkState netState
-      gs' <- liftIO $ reInitialize shuffPNames gs gen
+      gs' <- liftIO $ initialize shuffPNames gen
       gameState .= gs'
       let
         myRank = fromJust $ playerRank (netState^.myName) gs'

--- a/src/tools/node/Main.hs
+++ b/src/tools/node/Main.hs
@@ -110,6 +110,7 @@ executeCmd = do
       liftIO $ atomically $ modifyTVar nsTV $ status .~ Request (GameStart myRank)
     playTurn = case args of
       [n, strColor, slot] -> do
+        netState <- liftIO $ readTVarIO nsTV
         let
           changeNetState ns = case mPlayerTurn of
            Just pt -> ns & status     .~ Request pt
@@ -123,9 +124,9 @@ executeCmd = do
                 | slot `elem` [ "l", "left"  ] = Just $ Left  (Card n' (Just c))
                 | slot `elem` [ "r", "right" ] = Just $ Right (Card n' (Just c))
                 | otherwise                    = Nothing
-            PlayTurn <$> mCard
+            PlayTurn (netState ^. turnNumber) <$> mCard
         case mPlayerTurn of
-          Just (PlayTurn ec) -> do
+          Just (PlayTurn _ ec) -> do
             (mNumberOfCardsDrawn, gs') <- flip runStateT gs $ runMaybeT $ processPlayerTurnAction ec
             case mNumberOfCardsDrawn of
               Just nCardsToDraw  -> do

--- a/src/tools/node/Main.hs
+++ b/src/tools/node/Main.hs
@@ -111,9 +111,10 @@ executeCmd = do
     playTurn = case args of
       [n, strColor, slot] -> do
         let
-          changeNetState gs' = case mPlayerTurn of
-           Just pt -> gs' & status .~ Request pt
-           _       -> gs'
+          changeNetState ns = case mPlayerTurn of
+           Just pt -> ns & status     .~ Request pt
+                         & turnNumber +~ 1
+           _       -> ns
           mPlayerTurn = do
             c    <- readMaybe strColor
             n'   <- readMaybe n

--- a/src/tools/node/Main.hs
+++ b/src/tools/node/Main.hs
@@ -277,7 +277,7 @@ main = do
   nsTV    <- liftIO (newTVarIO def)
   reqChan <- newTChanIO
   netChan <- newTChanIO
-  mv      <- myForkIO $ runReaderT (Network.loop def) (NetworkStateChannelData  nsTV reqChan netChan)
+  mv      <- myForkIO $ Network.loop def (NetworkTwoWayChannel reqChan netChan)
   void $ M.defaultMain app $ NodeState { _focusRing                 = F.focusRing $ enumFrom minBound
                                        , _inputEditor               = E.editor Input Nothing ""
                                        , _logText                   = []

--- a/src/tools/node/Main.hs
+++ b/src/tools/node/Main.hs
@@ -22,7 +22,6 @@ import Text.Read
 import Control.Monad
 import Control.Monad.Trans.Maybe
 import Control.Monad.State
-import Control.Monad.Reader
 import Control.Lens
 import Control.Concurrent
 import Control.Concurrent.STM

--- a/src/tools/node/Main.hs
+++ b/src/tools/node/Main.hs
@@ -143,7 +143,8 @@ executeCmd = do
           gs' <- flip execStateT gs $ do
             runMaybeT $ processPlayerTurnAction ec
           gameState .= gs'
-          liftIO $ atomically $ modifyTVar nsTV $ gameTurns %~ Map.delete n
+          liftIO $ atomically $ modifyTVar nsTV $ \ ns -> ns & gameTurns  %~ Map.delete n
+                                                             & turnNumber +~ 1
         _ -> logText %= (<>["err.. Aucun tour à traiter!"])
     resetNetwork = liftIO $ atomically $ modifyTVar nsTV $ status .~ Request ResetNetwork
     printGameState = do

--- a/src/tools/node/Main.hs
+++ b/src/tools/node/Main.hs
@@ -112,7 +112,7 @@ executeCmd = do
       gs' <- liftIO $ reInitialize shuffledPlayerNames gs gen
       gameState .= gs'
       let
-        myRank = fromJust $ List.elemIndex (netState^.myName) $ map (view name) (gs'^.players)
+        myRank = fromJust $ playerRank (netState^.myName) gs'
       liftIO $ atomically $ modifyTVar nsTV $ status .~ Request (GameStart myRank)
     playTurn = case args of
       [n, strColor, slot] -> do

--- a/src/tools/node/Main.hs
+++ b/src/tools/node/Main.hs
@@ -13,14 +13,11 @@
 
 module Main where
 
-import qualified Data.List as List
 import Data.Default
 import Data.Maybe
 import qualified Data.Map as Map
 
 import Text.Read
-
-import Numeric
 
 import Control.Monad
 import Control.Monad.Trans.Maybe
@@ -29,8 +26,6 @@ import Control.Monad.Reader
 import Control.Lens
 import Control.Concurrent
 import Control.Concurrent.STM
-
-import System.Random
 
 import Brick.AttrMap
 import Brick.Types ( BrickEvent
@@ -54,12 +49,12 @@ import qualified Brick.Focus as F
 import Graphics.Vty (defAttr)
 import qualified Graphics.Vty as V
 
-import Random
 import Cards
 import Game
 import GameState
 import Network
 import NetworkState
+import qualified OnlineGame
 
 data AppFocus = Input
               | Log
@@ -106,10 +101,9 @@ executeCmd = do
     startGame = do
       netState <- liftIO $ readTVarIO nsTV
       let
-        sortedPlayerNames   = List.sort $ Map.elems $ netState ^. playersIdentities
-        gen                 = mkStdGen (fst $ head $ readHex $ netState^.gameSettings.gameCode)
-        shuffledPlayerNames = deterministiclyShuffle sortedPlayerNames gen
-      gs' <- liftIO $ reInitialize shuffledPlayerNames gs gen
+        shuffPNames = OnlineGame.shuffledPlayerNames netState gen
+        gen         = OnlineGame.randomGeneratorFromNetworkState netState
+      gs' <- liftIO $ reInitialize shuffPNames gs gen
       gameState .= gs'
       let
         myRank = fromJust $ playerRank (netState^.myName) gs'

--- a/src/tui/BrickNetworkBridge.hs
+++ b/src/tui/BrickNetworkBridge.hs
@@ -20,12 +20,13 @@ import Brick.BChan
 
 import NetworkState
 
-newtype NetworkBrickEvent = NetworkUpdate NetworkState
+newtype NetworkBrickEvent = NetworkBrickUpdate NetworkState
 
 updateNetworkState :: TChan NetworkChannelUpdate -> Brick.BChan.BChan NetworkBrickEvent -> IO Bool
 updateNetworkState netChan brickChan = atomically (readTChan netChan) >>= \ (NetworkChannelUpdate ns) -> case ns^.status of
    ShuttingDown -> return False
-   _            -> writeBChan brickChan (NetworkUpdate ns) >> return True
+   _            -> writeBChan brickChan (NetworkBrickUpdate ns) >> return True
+
 
 loop :: TChan NetworkChannelUpdate
      -> Brick.BChan.BChan NetworkBrickEvent

--- a/src/tui/BrickNetworkBridge.hs
+++ b/src/tui/BrickNetworkBridge.hs
@@ -1,0 +1,36 @@
+
+{-|
+  Module      : BrickNetworkBridge
+  Description : Module de liaison entre la couche réseau et l'interface Bric
+  Copyright   : (c) Simon Désaulniers, 2025
+  License     : GPL-3
+
+  Maintainer  : sim.desaulniers@gmail.com
+-}
+
+module BrickNetworkBridge ( NetworkBrickEvent (..)
+                          , loop
+                          ) where
+
+import Control.Lens
+import Control.Monad.Extra ( whileM )
+import Control.Concurrent.STM
+
+import Brick.BChan
+
+import NetworkState
+
+newtype NetworkBrickEvent = NetworkUpdate NetworkState
+
+updateNetworkState :: TChan NetworkChannelUpdate -> Brick.BChan.BChan NetworkBrickEvent -> IO Bool
+updateNetworkState netChan brickChan = atomically (readTChan netChan) >>= \ (NetworkChannelUpdate ns) -> case ns^.status of
+   ShuttingDown -> return False
+   _            -> writeBChan brickChan (NetworkUpdate ns) >> return True
+
+loop :: TChan NetworkChannelUpdate
+     -> Brick.BChan.BChan NetworkBrickEvent
+     -> IO ()
+loop nchan bchan = whileM $ updateNetworkState nchan bchan
+
+--  vim: set sts=2 ts=2 sw=2 tw=120 et :
+

--- a/src/tui/BrickNetworkBridge.hs
+++ b/src/tui/BrickNetworkBridge.hs
@@ -27,7 +27,6 @@ updateNetworkState netChan brickChan = atomically (readTChan netChan) >>= \ (Net
    ShuttingDown -> return False
    _            -> writeBChan brickChan (NetworkBrickUpdate ns) >> return True
 
-
 loop :: TChan NetworkChannelUpdate
      -> Brick.BChan.BChan NetworkBrickEvent
      -> IO ()

--- a/src/tui/GameView.hs
+++ b/src/tui/GameView.hs
@@ -49,6 +49,7 @@ import Cards
 import GameState
 import qualified Game
 import ProgramState
+import qualified BrickNetworkBridge as BNB
 
 colorAttrFromCard :: Card -> Bool -> AttrName
 colorAttrFromCard c selected
@@ -106,7 +107,7 @@ playCard side = do
   theWinner <- Game.winner
   gameViewState . winner .= ((^.name) <$> theWinner)
 
-event :: T.BrickEvent AppFocus () -> T.EventM AppFocus ProgramState ()
+event :: T.BrickEvent AppFocus BNB.NetworkBrickEvent -> T.EventM AppFocus ProgramState ()
 event ev = do
   let
     quitOrNothing (T.VtyEvent (V.EvKey (V.KChar 'q') [] )) = goBackOrQuit
@@ -150,10 +151,10 @@ widget ps = winnerDialog ps <> [gameLogWidget] <> gameUI
                                                           $ vLimit 15
                                                           $ hLimit 30
                                                           $ viewport (Game (Just GameLog)) T.Vertical gameLogTextWidget
-    keybindBox         =  vBox $ over traverse (hLimit 50 . hBox)
-                               $ over (traverse.ix 0) (\ w ->  padLeft (Pad 2) w <+> fill ' ')
-                               $ over (traverse.ix 1) (\ w -> w <+> fill ' ')
-                               $ over (traverse.traverse) str keyBindText
+    keybindBox         = vBox $ over traverse (hLimit 50 . hBox)
+                              $ over (traverse.ix 0) (\ w ->  padLeft (Pad 2) w <+> fill ' ')
+                              $ over (traverse.ix 1) (\ w -> w <+> fill ' ')
+                              $ over (traverse.traverse) str keyBindText
     keyBindText        = [ ["gauche/droite", "Sélectionner une carte"]
                          , ["(z)",           "Jouer à gauche"        ]
                          , ["(c)",           "Jouer à droite"        ]

--- a/src/tui/GameView.hs
+++ b/src/tui/GameView.hs
@@ -184,8 +184,9 @@ winnerDialog ps =
                            ]
         _               -> []
 
-otherPlayerTurnWidget :: ProgramState -> [Widget AppFocus]
-otherPlayerTurnWidget ps
+otherPlayerTurnWidget :: ProgramState -> NS.NetworkStatus -> [Widget AppFocus]
+otherPlayerTurnWidget _ NS.Offline = []
+otherPlayerTurnWidget ps _
   | not (OnlineGame.isMyTurn ns) = [ C.centerLayer $ B.borderWithLabel popUpTitle $ popUpWidgetDimensions $ vBox [ fill ' ', msg, fill ' ' ] ]
   | otherwise                    = []
     where
@@ -195,7 +196,7 @@ otherPlayerTurnWidget ps
       currentPlayer = head $ ps ^. gameState . players
 
 widget :: ProgramState -> [Widget AppFocus]
-widget ps = winnerDialog ps <> otherPlayerTurnWidget ps <> [gameLogWidget] <> gameUI
+widget ps = winnerDialog ps <> otherPlayerTurnWidget ps (ns ^. NS.status) <> [gameLogWidget] <> gameUI
   where
     ns                 = ps ^. networkState
     players'           = ps ^. gameState . players
@@ -223,7 +224,7 @@ widget ps = winnerDialog ps <> otherPlayerTurnWidget ps <> [gameLogWidget] <> ga
     playerCardsButtons = zipWith (\ i c -> C.hCenter $ withAttr (colorAttrFromCard c False) $ btn i c) [0..]
     currentPlayer      = head players'
     currentCardsInHand = thisPlayer ns players' ^. cardsInHand
-    theCardsOnTable    = ps^.gameState.cardsOnTable
+    theCardsOnTable    = ps ^. gameState . cardsOnTable
     cardWidget c       = C.vCenter $ B.border $ vLimit 1 $ hLimit 2 $ C.center $ withAttr (colorAttrFromCard c False) $ str $ show $ c^.value
     centralCardWidget  = B.border . hLimit 15 . C.center . str
     cardsOnTableMatrix = [ [ cardWidget $ theCardsOnTable^.red._1

--- a/src/tui/GameView.hs
+++ b/src/tui/GameView.hs
@@ -222,15 +222,15 @@ widget ps = winnerDialog ps <> otherPlayerTurnWidget ps <> [gameLogWidget] <> ga
     cardWidget c       = C.vCenter $ B.border $ vLimit 1 $ hLimit 2 $ C.center $ withAttr (colorAttrFromCard c False) $ str $ show $ c^.value
     centralCardWidget  = B.border . hLimit 15 . C.center . str
     cardsOnTableMatrix = [ [ cardWidget $ theCardsOnTable^.red._1
-                           , withAttr (attrName "redcard") $ centralCardWidget $ ps^.programResources.blueCard10x15
+                           , withAttr (attrName "redcard") $ centralCardWidget $ ps^.programResources.redCard10x15
                            , cardWidget $ theCardsOnTable^.red._2
                            ]
                          , [ cardWidget $ theCardsOnTable^.yellow._1
-                           , withAttr (attrName "yellowcard") $ centralCardWidget $ ps^.programResources.redCard10x15
+                           , withAttr (attrName "yellowcard") $ centralCardWidget $ ps^.programResources.yellowCard10x15
                            , cardWidget $ theCardsOnTable^.yellow._2
                            ]
                          , [ cardWidget $ theCardsOnTable^.blue._1
-                           , withAttr (attrName "bluecard") $ centralCardWidget $ ps^.programResources.yellowCard10x15
+                           , withAttr (attrName "bluecard") $ centralCardWidget $ ps^.programResources.blueCard10x15
                            , cardWidget $ theCardsOnTable^.blue._2
                            ]
                          , [ cardWidget $ theCardsOnTable^.purple._1

--- a/src/tui/GameView.hs
+++ b/src/tui/GameView.hs
@@ -124,7 +124,7 @@ playCard sidedCard = do
 playMyTurn :: TVar NetworkState -> Either () () -> T.EventM AppFocus ProgramState ()
 playMyTurn nsTV side = liftIO (readTVarIO nsTV) >>= \ ns -> whenIsLocalPlayerTurn ns $ do
   thePlayers <- use (gameState . players)
-  cardIdx <- use (gameViewState . gameViewIndex)
+  cardIdx    <- use (gameViewState . gameViewIndex)
   let
     currentPlayer = head thePlayers
     card          = (currentPlayer^.cardsInHand) !! cardIdx
@@ -163,7 +163,7 @@ event nsTV ev = do
     mainEvent (T.VtyEvent (V.EvKey (V.KChar 'l') [] )) = goRight ns
     mainEvent (T.VtyEvent (V.EvKey V.KLeft       [] )) = goLeft ns
     mainEvent (T.VtyEvent (V.EvKey (V.KChar 'h') [] )) = goLeft ns
-    mainEvent (T.VtyEvent (V.EvKey (V.KChar 'q') [] )) = goBackOrQuit
+    mainEvent (T.VtyEvent (V.EvKey (V.KChar 'q') [] )) = use networkRequestChannel >>= OnlineGame.resetNetwork >> goBackOrQuit
     mainEvent _                                        = return ()
 
   Game.winner >>= \ case

--- a/src/tui/GameView.hs
+++ b/src/tui/GameView.hs
@@ -142,6 +142,7 @@ event nsTV ev = do
   let
     quitOrNothing (T.VtyEvent (V.EvKey (V.KChar 'q') [] )) = goBackOrQuit
     quitOrNothing _                                        = return ()
+
     mainEvent (T.VtyEvent (V.EvKey (V.KChar 'z') [] )) = playMyTurn nsTV (Left ())
     mainEvent (T.VtyEvent (V.EvKey (V.KChar 'c') [] )) = playMyTurn nsTV (Right ())
     mainEvent (T.VtyEvent (V.EvKey V.KRight      [] )) = goRight ns
@@ -150,6 +151,7 @@ event nsTV ev = do
     mainEvent (T.VtyEvent (V.EvKey (V.KChar 'h') [] )) = goLeft ns
     mainEvent (T.VtyEvent (V.EvKey (V.KChar 'q') [] )) = goBackOrQuit
     mainEvent _                                        = return ()
+
   Game.winner >>= \ case
     Just _ -> quitOrNothing ev
     _      -> mainEvent ev

--- a/src/tui/GameView.hs
+++ b/src/tui/GameView.hs
@@ -132,7 +132,6 @@ playMyTurn nsTV side = liftIO (readTVarIO nsTV) >>= \ ns -> when (OnlineGame.isM
 
 event :: TVar NetworkState -> T.BrickEvent AppFocus BNB.NetworkBrickEvent -> T.EventM AppFocus ProgramState ()
 event nsTV (T.AppEvent (BNB.NetworkBrickUpdate ns)) = do
-  liftIO $ appendFile ("/tmp/toto"<> ns ^. NS.myID <>".txt") $ show ns
   let (turns, ns') = OnlineGame.consumeConsecutivePlayerTurns ns
   forM_ turns $ \ (_, card) -> playCard card
   networkState .= ns'

--- a/src/tui/GameView.hs
+++ b/src/tui/GameView.hs
@@ -79,7 +79,7 @@ attrs = [ ]
 
 localPlayer :: NetworkState -> [PlayerState] -> PlayerState
 localPlayer NS.NetworkState{NS._status = NS.Offline} thePlayers = head thePlayers
-localPlayer ns thePlayers              = thePlayers !! OnlineGame.myCurrentPosInPlayerList ns
+localPlayer ns thePlayers                                       = thePlayers !! OnlineGame.myCurrentPosInPlayerList ns
 
 whenIsLocalPlayerTurn :: Applicative f => NetworkState -> f () -> f ()
 whenIsLocalPlayerTurn NS.NetworkState{NS._status = NS.Offline} = id

--- a/src/tui/GameView.hs
+++ b/src/tui/GameView.hs
@@ -136,7 +136,12 @@ playMyTurn nsTV side = liftIO (readTVarIO nsTV) >>= \ ns -> when (OnlineGame.isM
     ec   = case side of
              Left {}  -> Left card
              Right {} -> Right card
+
   playCard ec
+
+  resultingHand <- use (gameState . players . _last . cardsInHand)
+  gameViewState . gameViewIndex %= min (length resultingHand - 1)
+
   case ns ^. NS.status of
     NS.Offline -> return ()
     _          -> liftIO $ atomically $ modifyTVar nsTV $ \ ns' -> ns' & NS.status     .~ NS.Request (NS.PlayTurn (ns' ^. NS.turnNumber) ec)

--- a/src/tui/GameView.hs
+++ b/src/tui/GameView.hs
@@ -19,11 +19,8 @@ import Data.Either.Extra
 import qualified Data.Text as Text
 
 import Control.Monad
-import Control.Monad.IO.Class
 import Control.Lens
 import Control.Monad.Trans.Maybe
-
-import Control.Concurrent.STM
 
 import Brick.AttrMap
 import Brick.Focus ( focusSetCurrent

--- a/src/tui/GameView.hs
+++ b/src/tui/GameView.hs
@@ -90,9 +90,9 @@ goLeft ns = whenIsLocalPlayerTurn ns $ gameViewState.gameViewIndex %= max 0 . su
 
 goRight :: NetworkState -> T.EventM AppFocus ProgramState ()
 goRight ns = whenIsLocalPlayerTurn ns $ do
-        thePlayers <- use (gameState . players)
+  thePlayers <- use (gameState . players)
   let p = localPlayer ns thePlayers
-        gameViewState.gameViewIndex %= min ((+ (-1)) $ length $ p ^. cardsInHand) . (+ 1)
+  gameViewState.gameViewIndex %= min ((+ (-1)) $ length $ p ^. cardsInHand) . (+ 1)
 
 goBackOrQuit :: T.EventM AppFocus ProgramState ()
 goBackOrQuit = do
@@ -122,15 +122,15 @@ playCard sidedCard = do
   gameViewState . winner .= ((^.name) <$> theWinner)
 
 playMyTurn :: TVar NetworkState -> Either () () -> T.EventM AppFocus ProgramState ()
-playMyTurn nsTV side = liftIO (readTVarIO nsTV) >>= \ ns -> when (OnlineGame.isMyTurn ns) $ do
+playMyTurn nsTV side = liftIO (readTVarIO nsTV) >>= \ ns -> whenIsLocalPlayerTurn ns $ do
   thePlayers <- use (gameState . players)
-  let currentPlayer = head thePlayers
   cardIdx <- use (gameViewState . gameViewIndex)
   let
-    card = (currentPlayer^.cardsInHand) !! cardIdx
-    ec   = case side of
-             Left {}  -> Left card
-             Right {} -> Right card
+    currentPlayer = head thePlayers
+    card          = (currentPlayer^.cardsInHand) !! cardIdx
+    ec            = case side of
+                      Left {}  -> Left card
+                      Right {} -> Right card
 
   playCard ec
 

--- a/src/tui/Main.hs
+++ b/src/tui/Main.hs
@@ -46,7 +46,7 @@ import qualified BrickNetworkBridge as BNB
 appEvent :: TVar NetworkState -> BrickEvent AppFocus BNB.NetworkBrickEvent -> EventM AppFocus ProgramState ()
 appEvent nsTV e = use currentFocus >>= \ cf -> case focusGetCurrent cf of
   Just (MainMenu _) -> MainMenu.event nsTV e
-  Just (Game     _) -> GameView.event e
+  Just (Game     _) -> GameView.event nsTV e
   _                 -> return ()
 
 appChooseCursor :: ProgramState -> [CursorLocation AppFocus] -> Maybe (CursorLocation AppFocus)
@@ -88,7 +88,7 @@ app nsTV = M.App { M.appDraw         = drawUI
 
 main :: IO ()
 main = do
-  nsTV             <- liftIO (newTVarIO def)
+  nsTV      <- liftIO (newTVarIO def)
   brickchan <- liftIO $ newBChan 10
 
   let buildVty = mkVty VConfig.defaultConfig

--- a/src/tui/MainMenu.hs
+++ b/src/tui/MainMenu.hs
@@ -25,7 +25,6 @@ import Control.Lens
 import Control.Monad.State
 import Control.Monad.Reader
 import Control.Concurrent.STM
-import Control.Concurrent
 
 import Brick.Util
 import Brick.AttrMap

--- a/src/tui/MainMenu.hs
+++ b/src/tui/MainMenu.hs
@@ -165,8 +165,7 @@ event nsTV ev = do
             validFields          = validName && validNumberOfPlayers
           mainMenuState . submenu . _Just . gameForm %= setFieldValid validNumberOfPlayers numberOfPlayersField
           when validFields $ do
-            withNetwork nsTV $ resetNetwork nsTV >> OnlineGame.createGame nsTV playerName numberOfPlayers'
-
+            withNetwork nsTV $ OnlineGame.createGame nsTV playerName numberOfPlayers'
             mainMenuState . submenu .= Just (OnlineLobby Host)
         OtherPlayer -> do
           let
@@ -176,15 +175,15 @@ event nsTV ev = do
             gameCodeField = MainMenu (OnlineGameInitializationForm OnlineGameInitializationFormGameCodeField)
           mainMenuState . submenu . _Just . gameForm %= setFieldValid validCode gameCodeField
           when validFields $ do
-            withNetwork nsTV $ resetNetwork nsTV >> OnlineGame.joinGame nsTV playerName gc
+            withNetwork nsTV $ OnlineGame.joinGame nsTV playerName gc
             mainMenuState . submenu .= Just (OnlineLobby OtherPlayer)
 
     formEvents (OnlineGameInitialization f _) _ = nestEventM' f (handleFormEvent ev) >>= (mainMenuState . submenu . _Just . onlineGameForm .=)
 
     formEvents _ _ = error "MainMenu.event.formEvents: sous-menu invalide!"
 
-    onlineLobbyEvents (T.VtyEvent (V.EvKey V.KEsc []))        = goBackOrQuit
-    onlineLobbyEvents (T.VtyEvent (V.EvKey (V.KChar 'q') [])) = goBackOrQuit
+    onlineLobbyEvents (T.VtyEvent (V.EvKey V.KEsc []))        = resetNetwork nsTV >> goBackOrQuit
+    onlineLobbyEvents (T.VtyEvent (V.EvKey (V.KChar 'q') [])) = resetNetwork nsTV >> goBackOrQuit
     onlineLobbyEvents _                                       = return ()
 
   use (mainMenuState.submenu) >>= \ case

--- a/src/tui/MainMenu.hs
+++ b/src/tui/MainMenu.hs
@@ -6,8 +6,6 @@
   License      : GPL-3
 
   Maintainer   : sim.desaulniers@gmail.com
-  Contributors : Simon Désaulniers
-                 Xeno Kappel
 -}
 
 {-# LANGUAGE LambdaCase #-}

--- a/src/tui/MainMenu.hs
+++ b/src/tui/MainMenu.hs
@@ -9,6 +9,7 @@
 -}
 
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
 
 module MainMenu ( event
                 , attrs
@@ -21,7 +22,9 @@ import Data.Maybe
 
 import Control.Lens
 import Control.Monad.State
+import Control.Monad.Reader
 
+import Brick.Util
 import Brick.AttrMap
 import Brick.Forms
 import Brick.Focus ( focusSetCurrent
@@ -35,6 +38,7 @@ import qualified Brick.Main as M
 import qualified Brick.Widgets.Border as B
 import qualified Brick.Widgets.Border.Style as BS
 import qualified Brick.Widgets.Center as C
+import qualified Brick.Widgets.Edit as E
 import Brick.Widgets.Core ( Padding (Pad)
                           , padBottom
                           , padLeft
@@ -51,30 +55,44 @@ import Brick.Widgets.Core ( Padding (Pad)
 
 import qualified Graphics.Vty as V
 
+import OpenDHT.DhtRunner ( dhtConfig
+                         , nodeConfig
+                         , persistPath
+                         )
+
+import System.Directory
+
 import ProgramState
 import Widgets
 
 import Game
+import GameState
+import Network
+
+type MenuButtonActionPairList = [(NamedButton AppFocus, T.EventM AppFocus ProgramState ())]
 
 attrs :: [(AttrName, V.Attr)]
-attrs = [ ]
+attrs = [ (E.editAttr,        V.white `on` V.black)
+        , (E.editFocusedAttr, V.black `on` V.yellow)
+        ]
 
-goUp :: T.EventM AppFocus ProgramState ()
-goUp = mainMenuState.mainMenuIndex %= max 0 . subtract 1
+goUp :: (MonadState s m, Ord b, Num b) => ASetter s s b b -> m ()
+goUp menuIndexLens = menuIndexLens %= max 0 . subtract 1
 
-goDown :: T.EventM AppFocus ProgramState ()
-goDown = mainMenuState.mainMenuIndex %= min (length buttons - 1) . (+ 1)
+goDown :: (MonadState s m, Foldable t) => t a -> ASetter s s Int Int -> m ()
+goDown menuButtons menuIndexLens = menuIndexLens %= min (length menuButtons - 1) . (+ 1)
 
-selectEntry :: T.EventM AppFocus ProgramState ()
-selectEntry = do
-  i <- use $ mainMenuState.mainMenuIndex
-  let maction = over traverse snd buttons ^? ix i
+selectEntry :: MenuButtonActionPairList -> Traversal' ProgramState Int -> T.EventM AppFocus ProgramState ()
+selectEntry menuButtons menuIndexLens = do
+  mi <- preuse menuIndexLens
+  let maction = mi >>= \ i -> over traverse snd menuButtons ^? ix i
   fromMaybe (return ()) maction
 
 goBackOrQuit :: T.EventM AppFocus ProgramState ()
 goBackOrQuit = use (mainMenuState.submenu) >>= \ case
   Just (GameInitialization _)       -> mainMenuState.submenu .= Nothing
-  Just (OnlineGameInitialization _) -> mainMenuState.submenu .= Nothing
+  Just (OnlineGameSubMenu _)        -> mainMenuState.submenu .= Nothing
+  Just (OnlineGameInitialization _) -> mainMenuState.submenu .= Just (OnlineGameSubMenu 0)
   _                                 -> M.halt
 
 startGame :: [String] -> T.EventM AppFocus ProgramState ()
@@ -83,63 +101,90 @@ startGame playerList = do
   gameState <~ liftIO (initializeIO playerList)
   currentFocus %= focusSetCurrent (Game Nothing)
 
--- TODO: configurer le jeu et démarrer
-startOnlineGame :: String -> T.EventM AppFocus ProgramState ()
-startOnlineGame playerName = return ()
+createOnlineGame :: Text.Text -> Int -> T.EventM AppFocus ProgramState ()
+createOnlineGame playerName numberOfPlayers = do
+  ps <- get
+  unless (isJust (ps^.networkMV)) $ do
+    habangaCachePath <- liftIO $ getXdgDirectory XdgCache "habanga"
+    let dhtRunnerConf = def & dhtConfig.nodeConfig.persistPath .~ (habangaCachePath <> "/dht.cache")
+    mv <- liftIO $ forkFinallyWithMvar $ runReaderT (Network.loop dhtRunnerConf) (ps^?!gameState.networkState)
+    networkMV .= Just mv
+  -- TODO: créer la partie et afficher une fenêtre d'attente (avec possibilité d'annuler).
 
 event :: T.BrickEvent AppFocus () -> T.EventM AppFocus ProgramState ()
 event ev = do
   let
-    mainEvents (T.VtyEvent (V.EvKey V.KEnter      [])) = selectEntry
-    mainEvents (T.VtyEvent (V.EvKey V.KDown       [])) = goDown
-    mainEvents (T.VtyEvent (V.EvKey (V.KChar 'j') [])) = goDown
-    mainEvents (T.VtyEvent (V.EvKey V.KUp         [])) = goUp
-    mainEvents (T.VtyEvent (V.EvKey (V.KChar 'k') [])) = goUp
-    mainEvents (T.VtyEvent (V.EvKey V.KEsc        [])) = goBackOrQuit
-    mainEvents (T.VtyEvent (V.EvKey (V.KChar 'q') [])) = goBackOrQuit
-    mainEvents _                                       = return ()
+    buttonMenuEvents :: MenuButtonActionPairList -> Traversal' ProgramState Int -> T.BrickEvent AppFocus () -> T.EventM AppFocus ProgramState ()
+    buttonMenuEvents menuButtons menuIndexLens (T.VtyEvent (V.EvKey V.KEnter      [])) = selectEntry menuButtons menuIndexLens
+    buttonMenuEvents menuButtons menuIndexLens (T.VtyEvent (V.EvKey V.KDown       [])) = goDown menuButtons menuIndexLens
+    buttonMenuEvents menuButtons menuIndexLens (T.VtyEvent (V.EvKey (V.KChar 'j') [])) = goDown menuButtons menuIndexLens
+    buttonMenuEvents _           menuIndexLens (T.VtyEvent (V.EvKey V.KUp         [])) = goUp menuIndexLens
+    buttonMenuEvents _           menuIndexLens (T.VtyEvent (V.EvKey (V.KChar 'k') [])) = goUp menuIndexLens
+    buttonMenuEvents _           _             (T.VtyEvent (V.EvKey V.KEsc        [])) = goBackOrQuit
+    buttonMenuEvents _           _             (T.VtyEvent (V.EvKey (V.KChar 'q') [])) = goBackOrQuit
+    buttonMenuEvents _           _             _                                       = return ()
 
-    formEvents _  (T.VtyEvent (V.EvKey V.KEsc []))               = goBackOrQuit
+
+    formEvents _  (T.VtyEvent (V.EvKey V.KEsc [])) = goBackOrQuit
+
     formEvents (GameInitialization f)  (T.VtyEvent (V.EvKey (V.KChar 'g') [V.MCtrl])) = do
       (_, gameInfo) <- nestEventM f $ gets formState
       mainMenuState.submenu .= Nothing
       let playerNames = filter (not . null) $ map (Text.unpack . Text.strip) $ Text.lines $ gameInfo ^. playerNamesField
       unless (null playerNames) $ startGame playerNames
+
     formEvents (GameInitialization f) _ = do
         f' <- nestEventM' f (handleFormEvent ev)
         mainMenuState . submenu . _Just . gameForm .= f'
+
     formEvents (OnlineGameInitialization f) (T.VtyEvent (V.EvKey (V.KChar 'g') [V.MCtrl])) = do
       (_, onlineGameInfo) <- nestEventM f $ gets formState
       mainMenuState.submenu .= Nothing
-      -- TODO:
-      -- * récupérer le nom du joueur
-      -- * récupérer le nombre de joueurs (entre 1 et 6)
-      -- * démarrer l'attente de connexion des autres joueurs
+      let
+        validNumberOfPlayers = onlineGameInfo ^. numberOfPlayers > 1 && onlineGameInfo ^. numberOfPlayers <= 6
+        numberOfPlayersField = MainMenu (OnlineGameInitializationForm OnlineGameInitializationFormNumberOfPlayersField)
+      mainMenuState . submenu . _Just . gameForm %= setFieldValid validNumberOfPlayers numberOfPlayersField
+      when validNumberOfPlayers $ createOnlineGame (onlineGameInfo ^. myPlayerName) (onlineGameInfo ^. numberOfPlayers)
+
     formEvents (OnlineGameInitialization f) _ = do
         f' <- nestEventM' f (handleFormEvent ev)
         mainMenuState . submenu . _Just . onlineGameForm .= f'
+
+    formEvents _ _ = error "MainMenu.event.formEvents: sous-menu invalide!"
+
   use (mainMenuState.submenu) >>= \ case
     Just s@(GameInitialization _)       -> formEvents s ev
     Just s@(OnlineGameInitialization _) -> formEvents s ev
-    _                                   -> mainEvents ev
+    Just (OnlineGameSubMenu _)          -> buttonMenuEvents onlineGameMenuButtons (mainMenuState.submenu._Just.onlineGameMenuIndex) ev
+    _                                   -> buttonMenuEvents mainMenuButtons (mainMenuState.mainMenuIndex) ev
 
-buttons :: [(Int -> Int -> Int -> AttrName -> Widget AppFocus, T.EventM AppFocus ProgramState ())]
-buttons = [ (button "Jouer",          mainMenuState.submenu .= Just (GameInitialization (mkGameInitializationForm def))         )
-          , (button "Jouer en ligne", mainMenuState.submenu .= Just (OnlineGameInitialization (mkOnlineGameInitialization def)) )
-          , (button "Options",        return ()                                                                                 )
-          , (button "Quitter",        M.halt                                                                                    )
-          ]
+mainMenuButtons :: MenuButtonActionPairList
+mainMenuButtons = [ (button "Jouer",          gameInitializationFormAction)
+                  , (button "Jouer en ligne", onlineGameMenuAction        )
+                  , (button "Options",        return ()                   )
+                  , (button "Quitter",        M.halt                      )
+                  ]
+  where
+    gameInitializationFormAction = do
+      mainMenuState.submenu .= Just (GameInitialization (mkGameInitializationForm def))
+      currentFocus          %= focusSetCurrent (MainMenu (GameInitializationForm GameInitializationFormPlayerNamesField))
+    onlineGameMenuAction = do
+      mainMenuState.submenu .= Just (OnlineGameSubMenu 0)
+      currentFocus          %= focusSetCurrent OnlineGameMenu
+
+onlineGameMenuButtons :: MenuButtonActionPairList
+onlineGameMenuButtons = [ (button "Créer une partie",   onlineGameCreationAction)
+                        , (button "Joindre une partie", onlineGameJoinAction    )
+                        , (button "Annuler",            goBackOrQuit            )
+                        ]
+  where
+    onlineGameCreationAction = do
+      mainMenuState.submenu .= Just (OnlineGameInitialization (mkOnlineGameInitializationForm def))
+      currentFocus          %= focusSetCurrent (MainMenu (OnlineGameInitializationForm OnlineGameInitializationFormMyNameField))
+    onlineGameJoinAction = undefined
 
 titleWidth :: ProgramState -> Int
 titleWidth ps = length $ head $ lines (ps^.programResources.menuGameTitle)
-
-mkOnlineGameInitialization :: OnlineGameInitializationInfo -> Form OnlineGameInitializationInfo e AppFocus
-mkOnlineGameInitialization =
-    let label s w    = padLeft (Pad 1) $ padBottom (Pad 1) $ vLimit 2 (hLimit 20 $ str s <+> fill ' ') <+> w
-        focusedItem  = MainMenu (OnlineGameInitializationForm OnlineGameInitializationFormMyNameField)
-    in newForm [ label "Votre nom" @@= B.border
-                                   @@= editTextField myPlayerName focusedItem (Just 1)
-               ]
 
 mkGameInitializationForm :: GameInitializationInfo -> Form GameInitializationInfo e AppFocus
 mkGameInitializationForm =
@@ -148,6 +193,15 @@ mkGameInitializationForm =
         focusedItem  = MainMenu (GameInitializationForm GameInitializationFormPlayerNamesField)
     in newForm [ label "Nom des joueurs" @@= B.border
                                          @@= editTextField playerNamesField focusedItem mMaxNumNames
+               ]
+
+mkOnlineGameInitializationForm :: OnlineGameInitializationInfo -> Form OnlineGameInitializationInfo e AppFocus
+mkOnlineGameInitializationForm =
+    let label s w            = padLeft (Pad 1) $ padBottom (Pad 1) $ vLimit 2 (hLimit 25 $ str s <+> fill ' ') <+> w
+        myNameField          = MainMenu (OnlineGameInitializationForm OnlineGameInitializationFormMyNameField)
+        numberOfPlayersField = MainMenu (OnlineGameInitializationForm OnlineGameInitializationFormNumberOfPlayersField)
+    in newForm [ label "Votre nom"               @@= editTextField myPlayerName myNameField (Just 1)
+               , label "Nombre de joueurs (1-6)" @@= editShowableField numberOfPlayers numberOfPlayersField
                ]
 
 gameInitializationSubMenu :: ProgramState -> [Widget AppFocus]
@@ -173,6 +227,27 @@ onlineGameInitializationSubMenu ps =
      Just (OnlineGameInitialization _) -> [C.centerLayer submenuWidget]
      _                                 -> []
 
+-- TODO
+onlineGameSubMenu :: ProgramState -> [Widget AppFocus]
+onlineGameSubMenu ps =
+  let
+    windowTitleStr = str "Jeu en ligne"
+    submenuWidget  = B.borderWithLabel windowTitleStr $ hLimit (titleWidth ps + 4) $ vLimit 25 $ vBox contentWidget
+    contentWidget  = [buttonMenu onlineGameMenuButtons (mainMenuState.submenu._Just.onlineGameMenuIndex) ps]
+   in case ps ^. mainMenuState . submenu of
+     Just (OnlineGameSubMenu _) -> [C.centerLayer submenuWidget]
+     _                          -> []
+
+buttonMenu :: MenuButtonActionPairList -> Traversal' ProgramState Int -> ProgramState -> Widget AppFocus
+buttonMenu menuButtons menuIndexLens ps = vBox $ map C.center $ appendArgsToButtons (over traverse fst menuButtons) 25
+  where
+    -- Cette fonction est un peu moins évidente, mais elle assure que les
+    -- indices des boutons sont bien attribués et que la largeur de ceux-ci
+    -- est la même pour tous.
+    appendArgsToButtons bs width = fst (foldl (\ (l, i) f -> (l++[f i], i+1)) ([], 0) bs) <*> [width]
+                                                                                          <*> [ps^?!menuIndexLens]
+                                                                                          <*> [attrName "selectedAttr"]
+
 widget :: ProgramState -> [Widget AppFocus]
 widget ps = subMenus <> [ hBox [ leftPanel
                                , hLimit (titleWidth ps) middlePanel
@@ -180,7 +255,7 @@ widget ps = subMenus <> [ hBox [ leftPanel
                                ]
                         ]
   where
-    subMenus         = gameInitializationSubMenu ps <> onlineGameInitializationSubMenu ps
+    subMenus         = onlineGameSubMenu ps <> gameInitializationSubMenu ps <> onlineGameInitializationSubMenu ps
     sidePanelStyle a = C.center . withBorderStyle BS.unicodeRounded . B.border . withAttr (attrName a) . str
     leftPanel        = sidePanelStyle "bluecard"   $ ps^.programResources.blueCard35x53
     rightPanel       = sidePanelStyle "purplecard" $ ps^.programResources.purpleCard35x53
@@ -188,13 +263,7 @@ widget ps = subMenus <> [ hBox [ leftPanel
     middlePanel      = vBox [ C.hCenter $ str $ ps^.programResources.menuGameTitle
                             , C.hCenter $ B.borderWithLabel (str "Menu principal") $ hLimit (titleWidth ps) $ C.center menuOptions
                             ]
-    menuOptions      = vBox $ map C.center $ appendArgsToButtons (over traverse fst buttons) 25
-    -- Cette fonction est un peu moins évidente, mais elle assure que les
-    -- indices des boutons sont bien attribués et que la largeur de ceux-ci
-    -- est la même pour tous.
-    appendArgsToButtons bs width = fst (foldl (\ (l, i) f -> (l++[f i], i+1)) ([], 0) bs) <*> [width]
-                                                                                          <*> [ps^.mainMenuState.mainMenuIndex]
-                                                                                          <*> [attrName "selectedAttr"]
+    menuOptions      = buttonMenu mainMenuButtons (mainMenuState.mainMenuIndex) ps
 
 --  vim: set sts=2 ts=2 sw=2 tw=120 et :
 

--- a/src/tui/MainMenu.hs
+++ b/src/tui/MainMenu.hs
@@ -165,7 +165,8 @@ event nsTV ev = do
             validFields          = validName && validNumberOfPlayers
           mainMenuState . submenu . _Just . gameForm %= setFieldValid validNumberOfPlayers numberOfPlayersField
           when validFields $ do
-            withNetwork nsTV $ OnlineGame.createGame nsTV playerName numberOfPlayers'
+            withNetwork nsTV $ resetNetwork nsTV >> OnlineGame.createGame nsTV playerName numberOfPlayers'
+
             mainMenuState . submenu .= Just (OnlineLobby Host)
         OtherPlayer -> do
           let
@@ -175,15 +176,15 @@ event nsTV ev = do
             gameCodeField = MainMenu (OnlineGameInitializationForm OnlineGameInitializationFormGameCodeField)
           mainMenuState . submenu . _Just . gameForm %= setFieldValid validCode gameCodeField
           when validFields $ do
-            withNetwork nsTV $ OnlineGame.joinGame nsTV playerName gc
+            withNetwork nsTV $ resetNetwork nsTV >> OnlineGame.joinGame nsTV playerName gc
             mainMenuState . submenu .= Just (OnlineLobby OtherPlayer)
 
     formEvents (OnlineGameInitialization f _) _ = nestEventM' f (handleFormEvent ev) >>= (mainMenuState . submenu . _Just . onlineGameForm .=)
 
     formEvents _ _ = error "MainMenu.event.formEvents: sous-menu invalide!"
 
-    onlineLobbyEvents (T.VtyEvent (V.EvKey V.KEsc []))        = resetNetwork nsTV >> goBackOrQuit
-    onlineLobbyEvents (T.VtyEvent (V.EvKey (V.KChar 'q') [])) = resetNetwork nsTV >> goBackOrQuit
+    onlineLobbyEvents (T.VtyEvent (V.EvKey V.KEsc []))        = goBackOrQuit
+    onlineLobbyEvents (T.VtyEvent (V.EvKey (V.KChar 'q') [])) = goBackOrQuit
     onlineLobbyEvents _                                       = return ()
 
   use (mainMenuState.submenu) >>= \ case

--- a/src/tui/MainMenu.hs
+++ b/src/tui/MainMenu.hs
@@ -120,10 +120,8 @@ event ev = do
     buttonMenuEvents menuButtons menuIndexLens (T.VtyEvent (V.EvKey (V.KChar 'j') [])) = goDown menuButtons menuIndexLens
     buttonMenuEvents _           menuIndexLens (T.VtyEvent (V.EvKey V.KUp         [])) = goUp menuIndexLens
     buttonMenuEvents _           menuIndexLens (T.VtyEvent (V.EvKey (V.KChar 'k') [])) = goUp menuIndexLens
-    buttonMenuEvents _           _             (T.VtyEvent (V.EvKey V.KEsc        [])) = goBackOrQuit
     buttonMenuEvents _           _             (T.VtyEvent (V.EvKey (V.KChar 'q') [])) = goBackOrQuit
     buttonMenuEvents _           _             _                                       = return ()
-
 
     formEvents _  (T.VtyEvent (V.EvKey V.KEsc [])) = goBackOrQuit
 

--- a/src/tui/MainMenu.hs
+++ b/src/tui/MainMenu.hs
@@ -10,6 +10,7 @@
 
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
 
 module MainMenu ( event
                 , attrs
@@ -89,8 +90,10 @@ selectEntry menuButtons menuIndexLens = do
   let maction = mi >>= \ i -> over traverse snd menuButtons ^? ix i
   fromMaybe (return ()) maction
 
-resetNetwork :: MonadIO m =>  TVar NetworkState -> m ()
-resetNetwork nsTV = Network.requestNetwork nsTV NS.ResetNetwork
+resetNetwork :: (MonadIO m, MonadState ProgramState m) =>  TVar NetworkState -> m ()
+resetNetwork nsTV = do
+  networkState .= def
+  Network.requestNetwork nsTV NS.ResetNetwork
 
 goBackOrQuit :: T.EventM AppFocus ProgramState ()
 goBackOrQuit = use (mainMenuState.submenu) >>= \ case

--- a/src/tui/ProgramState.hs
+++ b/src/tui/ProgramState.hs
@@ -55,8 +55,12 @@ instance Default ProgramResources where
 data GameInitializationFormElement = GameInitializationFormPlayerNamesField
   deriving (Eq, Ord, Show, Enum)
 
+data OnlineGameInitializationFormElement = OnlineGameInitializationFormMyNameField
+  deriving (Eq, Ord, Show, Enum)
+
 data MainMenuFocusableElement = MainMenuButtons
                               | GameInitializationForm GameInitializationFormElement
+                              | OnlineGameInitializationForm OnlineGameInitializationFormElement
                               deriving (Eq, Ord, Show)
 
 data GameFocusableSubElement = GameLog
@@ -74,8 +78,17 @@ makeLenses ''GameInitializationInfo
 instance Default GameInitializationInfo where
   def = GameInitializationInfo mempty
 
-newtype MainMenuSubMenu = GameInitialization { _gameForm :: Form GameInitializationInfo () AppFocus
-                                             }
+newtype OnlineGameInitializationInfo = OnlineGameInitializationInfo { _myPlayerName :: T.Text }
+  deriving Show
+makeLenses ''OnlineGameInitializationInfo
+
+instance Default OnlineGameInitializationInfo where
+  def = OnlineGameInitializationInfo mempty
+
+data MainMenuSubMenu = GameInitialization { _gameForm :: Form GameInitializationInfo () AppFocus
+                                          }
+                     | OnlineGameInitialization { _onlineGameForm :: Form OnlineGameInitializationInfo () AppFocus
+                                                }
 makeLenses ''MainMenuSubMenu
 
 data MainMenuState = MainMenuState { _mainMenuIndex :: Int
@@ -110,6 +123,7 @@ instance Default ProgramState where
                      , _gameViewState    = def
                      , _currentFocus     = focusRing [ MainMenu MainMenuButtons
                                                      , MainMenu (GameInitializationForm GameInitializationFormPlayerNamesField)
+                                                     , MainMenu (OnlineGameInitializationForm OnlineGameInitializationFormMyNameField)
                                                      , OptionsMenu
                                                      , Game Nothing
                                                      ]

--- a/src/tui/Widgets.hs
+++ b/src/tui/Widgets.hs
@@ -8,7 +8,8 @@
   Maintainer  : sim.desaulniers@gmail.com
 -}
 
-module Widgets ( button
+module Widgets ( NamedButton
+               , button
                , buttonAttrs
                ) where
 
@@ -22,6 +23,9 @@ import Brick.Widgets.Core ( hLimit
                           )
 
 import qualified Graphics.Vty as V
+
+-- Signature de `button` avec son premier paramètre appliqué.
+type NamedButton n = Int -> Int -> Int -> AttrName -> Widget n
 
 buttonAttrs :: [(AttrName, V.Attr)]
 buttonAttrs = [ ]

--- a/src/tui/Widgets.hs
+++ b/src/tui/Widgets.hs
@@ -11,6 +11,7 @@
 module Widgets ( NamedButton
                , button
                , buttonAttrs
+               , popUpWidgetDimensions
                ) where
 
 import Brick.AttrMap
@@ -18,6 +19,7 @@ import Brick.Types (Widget)
 import qualified Brick.Widgets.Border as B
 import qualified Brick.Widgets.Center as C
 import Brick.Widgets.Core ( hLimit
+                          , vLimit
                           , withAttr
                           , str
                           )
@@ -26,6 +28,9 @@ import qualified Graphics.Vty as V
 
 -- Signature de `button` avec son premier paramètre appliqué.
 type NamedButton n = Int -> Int -> Int -> AttrName -> Widget n
+
+popUpWidgetDimensions :: Widget n -> Widget n
+popUpWidgetDimensions = hLimit 40 . vLimit 5
 
 buttonAttrs :: [(AttrName, V.Attr)]
 buttonAttrs = [ ]


### PR DESCRIPTION
* core:
  * OnlineGame: nouveau module de fonctions de jeu en ligne communes
  * BrickNetworkBridge: canal entre le réseau et Brick
    * Le pont sert à découpler le réseau de Brick de façon à utiliser le même
      mécanisme de mise à jour dans une autre inteface.
    * Chaque mise-à-jour de l'état du réseau est écrite dans le canal de façon
      à la transmettre à l'interlocuteur. Un canal correspondant du côté de Brick
      est utilisé afin de fournir des événements sur lesquels agir pour chaque
      mise-à-jour réseau.
  * Game: retrait reInitialize qui ne sert plus depuis le retrait du
    constructeur OnlineGameState du type GameState.
  * Network:
    * changement du mode de passage de requête au module réseau pour une
      approche par canal de communication (FIFO) par message.
    * correction de la gestion défaillante du numéro du tour. Le module Network
      s'en charge pleinement
* tui:
  * MainMenu:
    * Implémentation des fonctions de création et accès à une partie en ligne
    * retrait <ESC> comme touche pour quitter le programme
    * fenêtre de hall de jeu avant démarrage du jeu
  * GameView:
    * Implémentation du jeu en multijoueur
    * Correction du dessin des cartes centrales. Toutes les couleurs sauf la
      couleur mauve étaient permutées;