### PR TITLE
fix(haskell-ci): usage du jeton GITHUB_TOKEN

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 jobs:
   build:
@@ -17,7 +18,7 @@ jobs:
       image: ghcr.io/sim590/habanga-ci
       credentials:
         username: sim590
-        password: ${{ secrets.DOCKER_CONTAINER_REGISTRY_TOKEN }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
Le secret DOCKER_CONTAINER_REGISTRY_TOKEN causait une erreur de
validation du gabarit GitHub Actions (valeur évaluée à ''),
bloquant l'exécution du pipeline CI.

GITHUB_TOKEN avec la permission packages:read est l'approche
recommandée pour récupérer des images depuis ghcr.io. Il est généré
automatiquement à chaque exécution, sans jeton personnel à gérer
ni risque de valeur vide.